### PR TITLE
Fix executor proxy web app build

### DIFF
--- a/Biflow.Aspire.ServiceDefaults/Biflow.Aspire.ServiceDefaults.csproj
+++ b/Biflow.Aspire.ServiceDefaults/Biflow.Aspire.ServiceDefaults.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="JetBrains.Annotations" />
-    <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery"/>
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/Biflow.Aspire.ServiceDefaults/Extensions.cs
+++ b/Biflow.Aspire.ServiceDefaults/Extensions.cs
@@ -19,11 +19,10 @@ namespace Microsoft.Extensions.Hosting;
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
-    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder,
-        bool addDbHealthCheck = false)
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
     {
         builder.ConfigureOpenTelemetry();
-        builder.AddDefaultHealthChecks(addDbHealthCheck);
+        builder.AddDefaultHealthChecks();
         builder.Services.AddServiceDiscovery();
         builder.Services.ConfigureHttpClientDefaults(http =>
         {
@@ -91,28 +90,11 @@ public static class Extensions
         return builder;
     }
 
-    private static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder,
-        bool addDbHealthCheck)
+    private static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
     {
-        var healthChecks = builder.Services.AddHealthChecks();
-        
-        healthChecks
-            // Add a default liveness check to ensure the app is responsive
-            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live", "common"]);
-
-        if (!addDbHealthCheck)
-        {
-            return builder;
-        }
-        
-        // Add a default database health check to ensure the app database is accessible
-        var connectionString = builder.Configuration.GetConnectionString("AppDbContext");
-        ArgumentNullException.ThrowIfNull(connectionString);
-        healthChecks.AddTypeActivatedCheck<AppDbHealthCheck>(
-            name: "database",
-            failureStatus: null,
-            tags: ["common"],
-            args: connectionString);
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
 
         return builder;
     }

--- a/Biflow.DataAccess/AppDbHealthCheck.cs
+++ b/Biflow.DataAccess/AppDbHealthCheck.cs
@@ -1,7 +1,7 @@
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-namespace Microsoft.Extensions.Hosting;
+namespace Biflow.DataAccess;
 
 internal class AppDbHealthCheck(string connectionString) : IHealthCheck
 {
@@ -15,9 +15,9 @@ internal class AppDbHealthCheck(string connectionString) : IHealthCheck
                 ConnectionString = connectionString,
                 ConnectTimeout = 8 // Use a fixed connection timeout
             };
-            await using var connection = new SqlConnection(connStrBuilder.ConnectionString);;
+            await using var connection = new SqlConnection(connStrBuilder.ConnectionString);
             await connection.OpenAsync(cancellationToken);
-            var command = new SqlCommand("SELECT 1", connection);
+            await using var command = new SqlCommand("SELECT 1", connection);
             await command.ExecuteNonQueryAsync(cancellationToken);
             return HealthCheckResult.Healthy(
                 description: "App database connection test successful",

--- a/Biflow.Executor.WebApp/Program.cs
+++ b/Biflow.Executor.WebApp/Program.cs
@@ -1,4 +1,5 @@
 using Biflow.Core;
+using Biflow.DataAccess;
 using Biflow.Executor.Core;
 using Biflow.ExecutorProxy.Core.Authentication;
 using Microsoft.OpenApi.Models;
@@ -6,7 +7,8 @@ using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddServiceDefaults(addDbHealthCheck: true);
+builder.AddServiceDefaults()
+    .AddDatabaseHealthCheck();
 
 builder.Services.AddWindowsService();
 builder.Services.AddSystemd();

--- a/Biflow.ExecutorProxy.WebApp/Program.cs
+++ b/Biflow.ExecutorProxy.WebApp/Program.cs
@@ -54,6 +54,7 @@ baseGroup.MapFileExplorerEndpoints();
 if (app.Environment.IsDevelopment())
 {
     app.MapGet("/health", () => Results.Text("Healthy")); // Skip authentication for health checks in development.
+    app.MapGet("/alive", () => Results.Text("Healthy"));
     app.UseSwagger();
     app.UseSwaggerUI();
 }
@@ -62,6 +63,7 @@ else
     // MapDefaultEndpoints() adds health check endpoint when running in development mode.
     // In production, add health check endpoint manually with auth enabled (baseGroup).
     baseGroup.MapGet("/health", () => Results.Text("Healthy"));
+    baseGroup.MapGet("/alive", () => Results.Text("Healthy"));
 }
 
 app.Run();

--- a/Biflow.Scheduler.WebApp/Program.cs
+++ b/Biflow.Scheduler.WebApp/Program.cs
@@ -1,4 +1,5 @@
 using Biflow.Core;
+using Biflow.DataAccess;
 using Biflow.Executor.Core;
 using Biflow.ExecutorProxy.Core.Authentication;
 using Biflow.Scheduler.Core;
@@ -9,7 +10,8 @@ using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddServiceDefaults(addDbHealthCheck: true);
+builder.AddServiceDefaults()
+    .AddDatabaseHealthCheck();
 
 builder.Services.AddWindowsService();
 builder.Services.AddSystemd();

--- a/Biflow.Ui.Api/Program.cs
+++ b/Biflow.Ui.Api/Program.cs
@@ -12,7 +12,8 @@ using Swashbuckle.AspNetCore.SwaggerUI;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddServiceDefaults(addDbHealthCheck: true);
+builder.AddServiceDefaults()
+    .AddDatabaseHealthCheck();
 
 builder.Services.AddWindowsService();
 builder.Services.AddSystemd();

--- a/Biflow.Ui/Program.cs
+++ b/Biflow.Ui/Program.cs
@@ -10,7 +10,8 @@ using Biflow.Ui.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddServiceDefaults(addDbHealthCheck: true);
+builder.AddServiceDefaults()
+    .AddDatabaseHealthCheck();
 
 builder.Services.AddWindowsService();
 builder.Services.AddSystemd();


### PR DESCRIPTION
Fixes the executor proxy web app native AOT build which was broken due to the app db health check being implemented in the service defaults project. App db health check was moved to data access project.