### PR TITLE
Build/publish script

### DIFF
--- a/build/Publish.ps1
+++ b/build/Publish.ps1
@@ -1,0 +1,235 @@
+### !IMPORTANT! Use PowerShell 7 to run the script.
+# Creating zip archives with Windows PowerShell is incompatible with az webapp deploy.
+
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ProjectBasePath,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PublishBasePath,
+
+    [Parameter()]
+    [switch]$Api = $false,
+
+    [Parameter()]
+    [switch]$Executor = $false,
+
+    [Parameter()]
+    [switch]$Proxy = $false,
+
+    [Parameter()]
+    [switch]$Scheduler = $false,
+
+    [Parameter()]
+    [switch]$Ui = $false,
+
+    [Parameter()]
+    [switch]$Linux = $false,
+
+    [Parameter()]
+    [switch]$Win = $false,
+
+    [Parameter()]
+    [switch]$Zip = $false,
+
+    [Parameter()]
+    [switch]$KeepAppsettings = $false
+)
+
+function Get-OsShortName()
+{
+    $osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    $osArchDesc = switch ($osArch)
+    {
+        arm64 { "arm64" }
+        x86 { "x86" }
+        x64 { "x64" }
+        default { throw [System.NotSupportedException] "Unsupported OS architecture" }
+    }
+    $osDesc = if ($IsWindows) { "win" }
+    elseif ($IsLinux) { "linux" }
+    elseif ($IsMacOS) { "osx" }
+    else { throw [System.NotSupportedException] "Unsupported OS platform" }
+    return "$($osDesc)-$($osArchDesc)"
+}
+
+function Publish-WebApp([String]$ProjectPath, [String]$AppName, [String]$Runtime, [switch]$SelfContained, [String[]]$RemoveItems)
+{
+    $appId = "$($AppName)-$($Runtime)$(If ($SelfContained) { '-self-contained' } Else { '' })"
+    Write-Host "Publishing $($appId)"
+    $publishPath = Join-Path $PublishBasePath $appid
+    Remove-Item $publishPath -Recurse -Force -ErrorAction SilentlyContinue
+    if ($SelfContained)
+    {
+        dotnet publish $ProjectPath `
+            --configuration Release `
+            --runtime $Runtime `
+            --self-contained true `
+            --output $publishPath `
+            -p:PublishSingleFile=true `
+            -p:IncludeNativeLibrariesForSelfExtract=true `
+            -maxcpucount:1
+    }
+    else
+    {
+        dotnet publish $ProjectPath `
+            --configuration Release `
+            --runtime $Runtime `
+            --output $publishPath
+    }
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Host "Error publishing $($appId)"
+        throw [System.ApplicationException] "Build failed for $($appId)"
+    }
+    foreach ($item in $RemoveItems)
+    {
+        Join-Path $publishPath $item | Remove-Item
+    }
+    if ($Zip)
+    {
+        $path = Join-Path $publishPath "*"
+        $destinationPath = "$($publishPath).zip"
+        Remove-Item $destinationPath -Force -ErrorAction SilentlyContinue
+        Compress-Archive -Path $path -DestinationPath $destinationPath -Force
+    }
+}
+
+function Publish-WebAppAot([String]$ProjectPath, [String]$AppName, [String[]]$RemoveItems)
+{
+    $OsName = Get-OsShortName
+    $appId = "$($AppName)-$($OsName)-aot"
+    Write-Host "Publishing $($appId)"
+    $publishPath = Join-Path $PublishBasePath $appId
+    Remove-Item $publishPath -Recurse -Force -ErrorAction SilentlyContinue
+    dotnet publish $ProjectPath `
+        --configuration Release `
+        --output $publishPath `
+        -p:PublishAot=true
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Host "Error publishing $($appId)"
+        throw [System.ApplicationException] "Build failed for $($appId)"
+    }
+    foreach ($item in $RemoveItems)
+    {
+        Join-Path $publishPath $item | Remove-Item
+    }
+    if ($Zip)
+    {
+        $path = Join-Path $publishPath "*"
+        $destinationPath = "$($publishPath).zip"
+        Remove-Item $destinationPath -Force -ErrorAction SilentlyContinue
+        Compress-Archive -Path $path -DestinationPath $destinationPath -Force
+    }
+}
+
+$apiProjectPath = Join-Path $ProjectBasePath "Biflow.Ui.Api" "Biflow.Ui.Api.csproj"
+$executorProjectPath = Join-Path $ProjectBasePath "Biflow.Executor.WebApp" "Biflow.Executor.WebApp.csproj"
+$proxyProjectPath = Join-Path $ProjectBasePath "Biflow.ExecutorProxy.WebApp" "Biflow.ExecutorProxy.WebApp.csproj"
+$schedulerProjectPath = Join-Path $ProjectBasePath "Biflow.Scheduler.WebApp" "Biflow.Scheduler.WebApp.csproj"
+$uiProjectPath = Join-Path $ProjectBasePath "Biflow.Ui" "Biflow.Ui.csproj"
+
+try
+{
+    $ProjectBasePath = $ProjectBasePath.TrimEnd([System.IO.Path]::PathSeparator)
+    $PublishBasePath = $PublishBasePath.TrimEnd([System.IO.Path]::PathSeparator)
+    
+    $timer = [System.Diagnostics.Stopwatch]::new()
+    $timer.Start()
+
+    [string[]]$removeItems =
+        if ($KeepAppsettings) { "appsettings.*.json" }
+        else { "appsettings*.json" }
+
+    [string[]]$removeItemsSelfContainedLinux =
+        if ($KeepAppsettings) { "appsettings.*.json", "*.pdb", "*.staticwebassets.endpoints.json" }
+        else { "appsettings*.json", "*.pdb", "*.staticwebassets.endpoints.json" }
+
+    [string[]]$removeItemsSelfContainedWin =
+        if ($KeepAppsettings) { "appsettings.*.json", "*.pdb", "*.staticwebassets.endpoints.json", "web.config" }
+        else { "appsettings*.json", "*.pdb", "*.staticwebassets.endpoints.json", "web.config" }
+
+    [string[]]$removeItemsUiSelfContainedLinux =
+        if ($KeepAppsettings) { "appsettings.*.json", "*.pdb" }
+        else { "appsettings*.json", "*.pdb" }
+
+    [string[]]$removeItemsUiSelfContainedWin =
+        if ($KeepAppsettings) { "appsettings.*.json", "*.pdb", "web.config" }
+        else { "appsettings*.json", "*.pdb", "web.config" }
+
+    if ($Api -and $Linux)
+    {
+        Publish-WebApp -ProjectPath $apiProjectPath -AppName "api" -Runtime "linux-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $apiProjectPath -AppName "api" -Runtime "linux-x64" -SelfContained -RemoveItems $removeItemsSelfContainedLinux
+    }
+
+    if ($Api -and $Win)
+    {
+        Publish-WebApp -ProjectPath $apiProjectPath -AppName "api" -Runtime "win-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $apiProjectPath -AppName "api" -Runtime "win-x64" -SelfContained -RemoveItems $removeItemsSelfContainedWin
+    }
+
+    if ($Executor -and $Linux)
+    {
+        Publish-WebApp -ProjectPath $executorProjectPath -AppName "executor" -Runtime "linux-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $executorProjectPath -AppName "executor" -Runtime "linux-x64" -SelfContained -RemoveItems $removeItemsSelfContainedLinux
+    }
+
+    if ($Executor -and $Win)
+    {
+        Publish-WebApp -ProjectPath $executorProjectPath -AppName "executor" -Runtime "win-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $executorProjectPath -AppName "executor" -Runtime "win-x64" -SelfContained -RemoveItems $removeItemsSelfContainedWin
+    }
+
+    if ($Proxy -and (($Win -and $IsWindows) -or ($Linux -and $IsLinux)))
+    {
+        Publish-WebAppAot -ProjectPath $proxyProjectPath -AppName "proxy" -RemoveItems $removeItemsSelfContainedLinux
+    }
+
+    if ($Proxy -and $Linux)
+    {
+        Publish-WebApp -ProjectPath $proxyProjectPath -AppName "proxy" -Runtime "linux-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $proxyProjectPath -AppName "proxy" -Runtime "linux-x64" -SelfContained -RemoveItems $removeItemsSelfContainedLinux
+    }
+
+    if ($Proxy -and $Win)
+    {
+        Publish-WebApp -ProjectPath $proxyProjectPath -AppName "proxy" -Runtime "win-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $proxyProjectPath -AppName "proxy" -Runtime "win-x64" -SelfContained -RemoveItems $removeItemsSelfContainedWin
+    }
+
+    if ($Scheduler -and $Linux)
+    {
+        Publish-WebApp -ProjectPath $schedulerProjectPath -AppName "scheduler" -Runtime "linux-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $schedulerProjectPath -AppName "scheduler" -Runtime "linux-x64" -SelfContained -RemoveItems $removeItemsSelfContainedLinux
+    }
+
+    if ($Scheduler -and $Win)
+    {
+        Publish-WebApp -ProjectPath $schedulerProjectPath -AppName "scheduler" -Runtime "win-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $schedulerProjectPath -AppName "scheduler" -Runtime "win-x64" -SelfContained -RemoveItems $removeItemsSelfContainedWin
+    }
+
+    if ($Ui -and $Linux)
+    {
+        Publish-WebApp -ProjectPath $uiProjectPath -AppName "ui" -Runtime "linux-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $uiProjectPath -AppName "ui" -Runtime "linux-x64" -SelfContained -RemoveItems $removeItemsUiSelfContainedLinux
+    }
+
+    if ($Ui -and $Win)
+    {
+        Publish-WebApp -ProjectPath $uiProjectPath -AppName "ui" -Runtime "win-x64" -RemoveItems $removeItems
+        Publish-WebApp -ProjectPath $uiProjectPath -AppName "ui" -Runtime "win-x64" -SelfContained -RemoveItems $removeItemsUiSelfContainedWin
+    }
+
+    $timer.Stop()
+    Write-Host "Publish finished in $($timer.Elapsed)"
+}
+catch
+{
+    Write-Host "Error publishing one or more apps"
+    Write-Host $_.Exception.Message
+}

--- a/src/Biflow.ExecutorProxy.WebApp/Biflow.ExecutorProxy.WebApp.csproj
+++ b/src/Biflow.ExecutorProxy.WebApp/Biflow.ExecutorProxy.WebApp.csproj
@@ -9,10 +9,10 @@
         <!-- Allow NuGet and AOT warnings (Swashbuckle and Serilog) to remain as warnings -->
         <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;IL2104;IL3053</WarningsNotAsErrors>
         <ImplicitUsings>enable</ImplicitUsings>
+        <AssemblyName>BiflowProxy</AssemblyName>
         <AssemblyVersion>$(VersionName)</AssemblyVersion>
         <FileVersion>$(AssemblyVersion)</FileVersion>
         <Version>$(AssemblyVersion)</Version>
-        <PublishAot>true</PublishAot>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Biflow.Ui.Api/Biflow.Ui.Api.csproj
+++ b/src/Biflow.Ui.Api/Biflow.Ui.Api.csproj
@@ -4,6 +4,14 @@
         <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <!-- Allow NuGet warnings to remain as warnings -->
+        <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+        <AssemblyName>BiflowApi</AssemblyName>
+        <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+        <AssemblyVersion>$(VersionName)</AssemblyVersion>
+        <FileVersion>$(AssemblyVersion)</FileVersion>
+        <Version>$(AssemblyVersion)</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Biflow.Ui.Api/Biflow.Ui.Api.csproj
+++ b/src/Biflow.Ui.Api/Biflow.Ui.Api.csproj
@@ -18,5 +18,9 @@
     <ItemGroup>
       <ProjectReference Include="..\Biflow.Ui.Core\Biflow.Ui.Core.csproj" />
     </ItemGroup>
+    
+    <ItemGroup>
+        <Content Update="SampleRequests\*" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
+    </ItemGroup>
 
 </Project>

--- a/src/Biflow.Ui.Components/Biflow.Ui.Components.csproj
+++ b/src/Biflow.Ui.Components/Biflow.Ui.Components.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="wwwroot/icons/**" />
+    <Content Update="compilerconfig.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Biflow.Ui/Biflow.Ui.csproj
+++ b/src/Biflow.Ui/Biflow.Ui.csproj
@@ -16,18 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Remove="compilerconfig.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <_ContentIncludedByDefault Remove="wwwroot\css\bootstrap.custom.css" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="compilerconfig.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="BlazorMonaco" />
     <PackageReference Include="Havit.Blazor.Components.Web.Bootstrap" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
@@ -46,6 +34,15 @@
     <ProjectReference Include="..\Biflow.Ui.Icons\Biflow.Ui.Icons.csproj" />
     <ProjectReference Include="..\Biflow.Ui.SqlMetadataExtensions\Biflow.Ui.SqlMetadataExtensions.csproj" />
     <ProjectReference Include="..\Biflow.Ui.TableEditor\Biflow.Ui.TableEditor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <_ContentIncludedByDefault Remove="wwwroot\css\bootstrap.custom.css" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="compilerconfig.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
+    <Content Update="libman.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added reusable build/publish script written in PowerShell to support automated build/publish processes.

The script helps in publishing the various components/modules of the application by providing dedicated arguments for the different components. And more than anything, it provides a sample implementation of how to publish the components without unnecessary output files and for different runtimes (Windows, Linux, macOS).

Also minor publish related fixes to .csproj files.