### PR TITLE
HTTP steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Setting up / development environment
 
-Visual Studio 2022 is recommended as the IDE for development.
+Visual Studio 2022 or JetBrains Rider is recommended as the IDE for development.
 
 <a href="https://marketplace.visualstudio.com/items?itemName=Failwyn.WebCompiler64">Web Compiler 2022+</a> Visual Studio extension is used to compile the Scss code in `Biflow.Ui/wwwroot/scss/bootstrap.custom.scss`. The configuration file for compiling the Scss code is located in `Biflow.Ui/compilerconfig.json`.
 
@@ -86,6 +86,22 @@ The following new or existing files/classes need to be added or edited when addi
 - JobExecutorFactory
   - Add possible new navigation property include statements to the initial execution load command.
 
+### Biflow.Ui.Core
+
+**Add new classes**
+
+- CreateFooStep
+  - Command handler for creating new FooStep instance in the mediator pattern
+- UpdateFooStep
+  - Command handler for updating and existing FooStep in the mediator pattern
+
+**Update existing classes**
+
+- StepValidator
+  - Add potential new validation logic for the new step type.
+- VersionRevert
+  - Include potential new endpoint collections when handling environment version snapshot reverts.
+
 ### Biflow.Ui
 
 **Add new classes**
@@ -107,9 +123,16 @@ The following new or existing files/classes need to be added or edited when addi
 - DependenciesGraph
   - Add FooStepEditModal to the end of the component
 
-### Biflow.Ui.Core
+### Biflow.Ui.Api
+
+**Add new classes**
+
+- FooStepDto
+  - Record type used for endpoint inputs
 
 **Update existing classes**
 
-- VersionRevert
-  - Include potential new endpoint collections when handling environment version snapshot reverts.
+- StepsCreateEndpoints
+  - Add endpoint for FooStep
+- StepsUpdateEndpoints
+  - Add endpoint for FooStep

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Currently supported step types:
     - Run locally stored executables (e.g., Python or PowerShell scripts)
 - Mail
     - Send emails as part of your workflows
+- Http
+    - Send arbitrary HTTP requests
 - Job
     - Start another Biflow job as part of your workflow
 

--- a/src/Biflow.Core/Entities/Parameters/ParameterType.cs
+++ b/src/Biflow.Core/Entities/Parameters/ParameterType.cs
@@ -10,5 +10,6 @@ public enum ParameterType
     Function,
     Email,
     DatabricksNotebook,
-    Fabric
+    Fabric,
+    Http
 }

--- a/src/Biflow.Core/Entities/Step/Http/HttpBodyFormat.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpBodyFormat.cs
@@ -1,0 +1,7 @@
+namespace Biflow.Core.Entities;
+
+public enum HttpBodyFormat
+{
+    PlainText,
+    Json
+}

--- a/src/Biflow.Core/Entities/Step/Http/HttpHeader.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpHeader.cs
@@ -1,0 +1,11 @@
+namespace Biflow.Core.Entities;
+
+public record HttpHeader
+{
+    public HttpHeader(string key, string value) => (Key, Value) = (key, value);
+    
+    public HttpHeader() { }
+    
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/Biflow.Core/Entities/Step/Http/HttpStep.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpStep.cs
@@ -1,0 +1,96 @@
+using Biflow.Core.Interfaces;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Biflow.Core.Entities;
+
+public class HttpStep : Step, IHasTimeout, IHasStepParameters<HttpStepParameter>
+{
+    [JsonConstructor]
+    public HttpStep() : base(StepType.Http) { }
+
+    private HttpStep(HttpStep other, Job? targetJob) : base(other, targetJob)
+    {
+        TimeoutMinutes = other.TimeoutMinutes;
+        Url = other.Url;
+        Method = other.Method;
+        Body = other.Body;
+        BodyFormat = other.BodyFormat;
+        Headers = other.Headers;
+        DisableAsyncPattern = other.DisableAsyncPattern;
+        StepParameters = other.StepParameters
+            .Select(p => new HttpStepParameter(p, this, targetJob))
+            .ToList();
+    }
+        
+    [Required]
+    [Range(0, 2880)] // 48 hours
+    public double TimeoutMinutes { get; set; }
+
+    [MaxLength(2048)]
+    [Required]
+    public string Url { get; set; } = "";
+    
+    public HttpStepMethod Method { get; set; } = HttpStepMethod.Post;
+
+    public string? Body
+    {
+        get;
+        set => field = string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    public HttpBodyFormat BodyFormat
+    {
+        get;
+        set
+        {
+            field = value;
+            UpdateContentTypeHeader(value);
+        }
+    } = HttpBodyFormat.Json;
+    
+    public List<HttpHeader> Headers { get; init; } = [new("Content-Type", "application/json")];
+    
+    /// <summary>
+    /// Option to disable invoking HTTP GET on location given in response header of a HTTP 202 Response.
+    /// If set true, it stops invoking HTTP GET on http location given in response header.
+    /// If set false then continues to invoke HTTP GET call on location given in http response headers.
+    /// </summary>
+    public bool DisableAsyncPattern { get; set; }
+
+    [ValidateComplexType]
+    [JsonInclude]
+    public IList<HttpStepParameter> StepParameters { get; private set; } = new List<HttpStepParameter>();
+
+    public override StepExecution ToStepExecution(Execution execution) => new HttpStepExecution(this, execution);
+
+    public override HttpStep Copy(Job? targetJob = null) => new(this, targetJob);
+
+    private void UpdateContentTypeHeader(HttpBodyFormat bodyFormat)
+    {
+        var header = Headers.FirstOrDefault(h => h.Key == "Content-Type");
+        if (header is not null)
+        {
+            header.Value = bodyFormat switch
+            {
+                HttpBodyFormat.PlainText => "text/plain",
+                HttpBodyFormat.Json => "application/json",
+                _ => header.Value
+            };
+            return;
+        }
+        string mediaType;
+        switch (bodyFormat)
+        {
+            case HttpBodyFormat.PlainText:
+                mediaType = "text/plain";
+                break;
+            case HttpBodyFormat.Json:
+                mediaType = "application/json";
+                break;
+            default:
+                return;
+        }
+        Headers.Add(new HttpHeader("Content-Type", mediaType));
+    }
+}

--- a/src/Biflow.Core/Entities/Step/Http/HttpStepExecution.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpStepExecution.cs
@@ -1,0 +1,62 @@
+using Biflow.Core.Interfaces;
+using System.ComponentModel.DataAnnotations;
+using JetBrains.Annotations;
+
+namespace Biflow.Core.Entities;
+
+public class HttpStepExecution : StepExecution,
+    IHasTimeout,
+    IHasStepExecutionParameters<HttpStepExecutionParameter>,
+    IHasStepExecutionAttempts<HttpStepExecutionAttempt>
+{
+    public HttpStepExecution(string stepName) : base(stepName, StepType.Http)
+    {
+    }
+
+    public HttpStepExecution(HttpStep step, Execution execution) : base(step, execution)
+    {
+        TimeoutMinutes = step.TimeoutMinutes;
+        Url = step.Url;
+        Method = step.Method;
+        Body = step.Body;
+        Headers = step.Headers.ToArray();
+        DisableAsyncPattern = step.DisableAsyncPattern;
+
+        StepExecutionParameters = step.StepParameters
+            .Select(p => new HttpStepExecutionParameter(p, this))
+            .ToArray();
+        AddAttempt(new HttpStepExecutionAttempt(this));
+    }
+
+    public double TimeoutMinutes { get; [UsedImplicitly] private set; }
+    
+    [MaxLength(2048)]
+    public string Url { get; init; } = "";
+    
+    public HttpStepMethod Method { get; init; } = HttpStepMethod.Get;
+    
+    public string? Body { get; init; }
+    
+    public HttpHeader[] Headers { get; init; } = [];
+    
+    /// <summary>
+    /// Option to disable invoking HTTP GET on location given in response header of a HTTP 202 Response.
+    /// If set true, it stops invoking HTTP GET on http location given in response header.
+    /// If set false then continues to invoke HTTP GET call on location given in http response headers.
+    /// </summary>
+    public bool DisableAsyncPattern { get; init; }
+
+    public IEnumerable<HttpStepExecutionParameter> StepExecutionParameters { get; } = new List<HttpStepExecutionParameter>();
+
+    public override HttpStepExecutionAttempt AddAttempt(StepExecutionStatus withStatus = default)
+    {
+        var previous = StepExecutionAttempts.MaxBy(x => x.RetryAttemptIndex);
+        ArgumentNullException.ThrowIfNull(previous);
+        var next = new HttpStepExecutionAttempt((HttpStepExecutionAttempt)previous, previous.RetryAttemptIndex + 1)
+        {
+            ExecutionStatus = withStatus
+        };
+        AddAttempt(next);
+        return next;
+    }
+}

--- a/src/Biflow.Core/Entities/Step/Http/HttpStepExecutionAttempt.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpStepExecutionAttempt.cs
@@ -1,0 +1,18 @@
+namespace Biflow.Core.Entities;
+
+public class HttpStepExecutionAttempt : StepExecutionAttempt
+{
+    public HttpStepExecutionAttempt(StepExecutionStatus executionStatus)
+        : base(executionStatus, StepType.Http)
+    {
+    }
+
+    public HttpStepExecutionAttempt(HttpStepExecutionAttempt other, int retryAttemptIndex)
+        : base(other, retryAttemptIndex)
+    {
+    }
+
+    public HttpStepExecutionAttempt(HttpStepExecution execution) : base(execution)
+    {
+    }
+}

--- a/src/Biflow.Core/Entities/Step/Http/HttpStepExecutionParameter.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpStepExecutionParameter.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Biflow.Core.Entities;
+
+public class HttpStepExecutionParameter : StepExecutionParameterBase
+{
+    public HttpStepExecutionParameter(string parameterName, ParameterValue parameterValue)
+        : base(parameterName, parameterValue, ParameterType.Http)
+    {
+    }
+
+    public HttpStepExecutionParameter(HttpStepParameter parameter, HttpStepExecution execution) : base(parameter, execution)
+    {
+        StepExecution = execution;
+    }
+
+    [JsonIgnore]
+    public HttpStepExecution StepExecution { get; init; } = null!;
+
+    [JsonIgnore]
+    public override StepExecution BaseStepExecution => StepExecution;
+}

--- a/src/Biflow.Core/Entities/Step/Http/HttpStepMethod.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpStepMethod.cs
@@ -1,0 +1,10 @@
+namespace Biflow.Core.Entities;
+
+public enum HttpStepMethod
+{
+    Get,
+    Post,
+    Put,
+    Delete,
+    Patch
+}

--- a/src/Biflow.Core/Entities/Step/Http/HttpStepParameter.cs
+++ b/src/Biflow.Core/Entities/Step/Http/HttpStepParameter.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Biflow.Core.Entities;
+
+public class HttpStepParameter : StepParameterBase
+{
+    public HttpStepParameter() : base(ParameterType.Http)
+    {
+    }
+
+    internal HttpStepParameter(HttpStepParameter other, HttpStep step, Job? job) : base(other, step, job)
+    {
+        Step = step;
+    }
+
+    [JsonIgnore]
+    public HttpStep Step { get; init; } = null!;
+
+    [JsonIgnore]
+    public override Step BaseStep => Step;
+}

--- a/src/Biflow.Core/Entities/Step/Step.cs
+++ b/src/Biflow.Core/Entities/Step/Step.cs
@@ -22,6 +22,7 @@ namespace Biflow.Core.Entities;
 [JsonDerivedType(typeof(ScdStep), nameof(StepType.Scd))]
 [JsonDerivedType(typeof(DataflowStep), nameof(StepType.Dataflow))]
 [JsonDerivedType(typeof(FabricStep), nameof(StepType.Fabric))]
+[JsonDerivedType(typeof(HttpStep), nameof(StepType.Http))]
 public abstract class Step : IComparable, IAuditable
 {
     protected Step(StepType stepType)

--- a/src/Biflow.Core/Entities/Step/StepType.cs
+++ b/src/Biflow.Core/Entities/Step/StepType.cs
@@ -66,5 +66,9 @@ public enum StepType
     
     [Category("SQL Server", 5)]
     [Description("SQL Server Agent job")]
-    AgentJob
+    AgentJob,
+    
+    [Category("Other", 4)]
+    [Description("Send arbitrary HTTP request")]
+    Http
 }

--- a/src/Biflow.Core/Entities/StepExecution/StepExecution.cs
+++ b/src/Biflow.Core/Entities/StepExecution/StepExecution.cs
@@ -20,6 +20,7 @@ namespace Biflow.Core.Entities;
 [JsonDerivedType(typeof(ScdStepExecution), nameof(StepType.Scd))]
 [JsonDerivedType(typeof(DataflowStepExecution), nameof(StepType.Dataflow))]
 [JsonDerivedType(typeof(FabricStepExecution), nameof(StepType.Fabric))]
+[JsonDerivedType(typeof(HttpStepExecution), nameof(StepType.Http))]
 public abstract class StepExecution(string stepName, StepType stepType)
 {
     protected StepExecution(Step step, Execution execution) : this(step.StepName ?? "", step.StepType)

--- a/src/Biflow.Core/Entities/StepExecution/StepExecutionAttempt.cs
+++ b/src/Biflow.Core/Entities/StepExecution/StepExecutionAttempt.cs
@@ -20,6 +20,7 @@ namespace Biflow.Core.Entities;
 [JsonDerivedType(typeof(ScdStepExecutionAttempt), nameof(StepType.Scd))]
 [JsonDerivedType(typeof(DataflowStepExecutionAttempt), nameof(StepType.Dataflow))]
 [JsonDerivedType(typeof(FabricStepExecutionAttempt), nameof(StepType.Fabric))]
+[JsonDerivedType(typeof(HttpStepExecutionAttempt), nameof(StepType.Http))]
 public abstract class StepExecutionAttempt(StepExecutionStatus executionStatus, StepType stepType)
 {
     protected StepExecutionAttempt(StepExecutionAttempt other, int retryAttemptIndex)

--- a/src/Biflow.DataAccess/AppDbContext.cs
+++ b/src/Biflow.DataAccess/AppDbContext.cs
@@ -43,6 +43,7 @@ public class AppDbContext : DbContext
     public DbSet<DatabricksStep> DatabricksSteps => Set<DatabricksStep>();
     public DbSet<DbtStep> DbtSteps => Set<DbtStep>();
     public DbSet<ScdStep> ScdSteps => Set<ScdStep>();
+    public DbSet<HttpStep> HttpSteps => Set<HttpStep>();
     public DbSet<DataObject> DataObjects => Set<DataObject>();
     public DbSet<Execution> Executions => Set<Execution>();
     public DbSet<StepExecution> StepExecutions => Set<StepExecution>();

--- a/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepEntityTypeConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Biflow.DataAccess.Configuration;
+
+internal class HttpStepEntityTypeConfiguration : IEntityTypeConfiguration<HttpStep>
+{
+    public void Configure(EntityTypeBuilder<HttpStep> builder)
+    {
+        builder.Property(x => x.TimeoutMinutes).HasColumnName("TimeoutMinutes");
+        builder.Property(x => x.Url).HasColumnName("HttpUrl").IsUnicode(false);
+        builder.Property(x => x.Method).HasColumnName("HttpMethod");
+        builder.Property(x => x.Body).HasColumnName("HttpBody");
+        builder.Property(x => x.BodyFormat).HasColumnName("HttpBodyFormat");
+        builder.Property(x => x.Headers).HasColumnName("HttpHeaders").IsUnicode(false);
+        builder.Property(x => x.DisableAsyncPattern).HasColumnName("HttpDisableAsyncPattern");
+        builder.Property(x => x.Headers).HasConversion(
+            from => JsonSerializer.Serialize(from, null as JsonSerializerOptions),
+            to => JsonSerializer.Deserialize<List<HttpHeader>>(to, null as JsonSerializerOptions) ?? new(),
+            new ValueComparer<List<HttpHeader>>(
+                (x, y) => x != null && y != null && x.SequenceEqual(y),
+                x => x.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())),
+                x => x.ToList()));
+    }
+}

--- a/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepExecutionEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepExecutionEntityTypeConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json;
+
+namespace Biflow.DataAccess.Configuration;
+
+internal class HttpStepExecutionEntityTypeConfiguration : IEntityTypeConfiguration<HttpStepExecution>
+{
+    public void Configure(EntityTypeBuilder<HttpStepExecution> builder)
+    {
+        builder.Property(x => x.TimeoutMinutes).HasColumnName("TimeoutMinutes");
+        builder.Property(x => x.Url).HasColumnName("HttpUrl").IsUnicode(false);
+        builder.Property(x => x.Method).HasColumnName("HttpMethod");
+        builder.Property(x => x.Body).HasColumnName("HttpBody");
+        builder.Property(x => x.Headers).HasColumnName("HttpHeaders").IsUnicode(false);
+        builder.Property(x => x.DisableAsyncPattern).HasColumnName("HttpDisableAsyncPattern");
+        builder.Property(x => x.Headers).HasConversion(
+            from => JsonSerializer.Serialize(from, null as JsonSerializerOptions),
+            to => JsonSerializer.Deserialize<HttpHeader[]>(to, null as JsonSerializerOptions)
+                  ?? Array.Empty<HttpHeader>());
+    }
+}

--- a/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepExecutionParameterEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepExecutionParameterEntityTypeConfiguration.cs
@@ -1,0 +1,12 @@
+﻿namespace Biflow.DataAccess.Configuration;
+
+internal class HttpStepExecutionParameterEntityTypeConfiguration : IEntityTypeConfiguration<HttpStepExecutionParameter>
+{
+    public void Configure(EntityTypeBuilder<HttpStepExecutionParameter> builder)
+    {
+        builder.HasOne(p => p.StepExecution)
+            .WithMany(p => p.StepExecutionParameters)
+            .HasForeignKey("ExecutionId", "StepId")
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepParameterEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/Http/HttpStepParameterEntityTypeConfiguration.cs
@@ -1,0 +1,11 @@
+﻿namespace Biflow.DataAccess.Configuration;
+
+internal class HttpStepParameterEntityTypeConfiguration : IEntityTypeConfiguration<HttpStepParameter>
+{
+    public void Configure(EntityTypeBuilder<HttpStepParameter> builder)
+    {
+        builder.HasOne(p => p.Step)
+            .WithMany(p => p.StepParameters)
+            .OnDelete(DeleteBehavior.ClientCascade);
+    }
+}

--- a/src/Biflow.DataAccess/Configuration/Step/StepEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/StepEntityTypeConfiguration.cs
@@ -25,7 +25,8 @@ internal class StepEntityTypeConfiguration : IEntityTypeConfiguration<Step>
             .HasValue<DbtStep>(StepType.Dbt)
             .HasValue<ScdStep>(StepType.Scd)
             .HasValue<DataflowStep>(StepType.Dataflow)
-            .HasValue<FabricStep>(StepType.Fabric);
+            .HasValue<FabricStep>(StepType.Fabric)
+            .HasValue<HttpStep>(StepType.Http);
 
         builder.OwnsOne(s => s.ExecutionConditionExpression, ece =>
         {

--- a/src/Biflow.DataAccess/Configuration/Step/StepParameterEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/StepParameterEntityTypeConfiguration.cs
@@ -31,7 +31,8 @@ internal class StepParameterEntityTypeConfiguration : IEntityTypeConfiguration<S
             .HasValue<PipelineStepParameter>(ParameterType.Pipeline)
             .HasValue<EmailStepParameter>(ParameterType.Email)
             .HasValue<DatabricksStepParameter>(ParameterType.DatabricksNotebook)
-            .HasValue<FabricStepParameter>(ParameterType.Fabric);
+            .HasValue<FabricStepParameter>(ParameterType.Fabric)
+            .HasValue<HttpStepParameter>(ParameterType.Http);
 
         builder.OwnsOne(s => s.Expression, ece =>
         {

--- a/src/Biflow.DataAccess/Configuration/StepExecution/StepExecutionAttemptEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/StepExecution/StepExecutionAttemptEntityTypeConfiguration.cs
@@ -36,7 +36,8 @@ internal class StepExecutionAttemptEntityTypeConfiguration : IEntityTypeConfigur
             .HasValue<DbtStepExecutionAttempt>(StepType.Dbt)
             .HasValue<ScdStepExecutionAttempt>(StepType.Scd)
             .HasValue<DataflowStepExecutionAttempt>(StepType.Dataflow)
-            .HasValue<FabricStepExecutionAttempt>(StepType.Fabric);
+            .HasValue<FabricStepExecutionAttempt>(StepType.Fabric)
+            .HasValue<HttpStepExecutionAttempt>(StepType.Http);
 
         builder.Property(x => x.InfoMessages)
             .HasColumnName("InfoMessages")

--- a/src/Biflow.DataAccess/Configuration/StepExecution/StepExecutionEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/StepExecution/StepExecutionEntityTypeConfiguration.cs
@@ -23,7 +23,8 @@ internal class StepExecutionEntityTypeConfiguration : IEntityTypeConfiguration<S
             .HasValue<DbtStepExecution>(StepType.Dbt)
             .HasValue<ScdStepExecution>(StepType.Scd)
             .HasValue<DataflowStepExecution>(StepType.Dataflow)
-            .HasValue<FabricStepExecution>(StepType.Fabric);
+            .HasValue<FabricStepExecution>(StepType.Fabric)
+            .HasValue<HttpStepExecution>(StepType.Http);
 
         builder.OwnsOne(s => s.ExecutionConditionExpression, ece =>
         {

--- a/src/Biflow.DataAccess/Configuration/StepExecution/StepExecutionParameterEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/StepExecution/StepExecutionParameterEntityTypeConfiguration.cs
@@ -35,7 +35,8 @@ internal class StepExecutionParameterEntityTypeConfiguration : IEntityTypeConfig
             .HasValue<PipelineStepExecutionParameter>(ParameterType.Pipeline)
             .HasValue<EmailStepExecutionParameter>(ParameterType.Email)
             .HasValue<DatabricksStepExecutionParameter>(ParameterType.DatabricksNotebook)
-            .HasValue<FabricStepExecutionParameter>(ParameterType.Fabric);
+            .HasValue<FabricStepExecutionParameter>(ParameterType.Fabric)
+            .HasValue<HttpStepExecutionParameter>(ParameterType.Http);
 
         builder.OwnsOne(s => s.Expression, ece =>
         {

--- a/src/Biflow.DataAccess/Migrations/20250924062518_HttpStep.Designer.cs
+++ b/src/Biflow.DataAccess/Migrations/20250924062518_HttpStep.Designer.cs
@@ -5,6 +5,7 @@ using Biflow.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -12,9 +13,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Biflow.DataAccess.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250924062518_HttpStep")]
+    partial class HttpStep
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Biflow.DataAccess/Migrations/20250924062518_HttpStep.cs
+++ b/src/Biflow.DataAccess/Migrations/20250924062518_HttpStep.cs
@@ -1,0 +1,162 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Biflow.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class HttpStep : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "HttpBody",
+                schema: "app",
+                table: "Step",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpBodyFormat",
+                schema: "app",
+                table: "Step",
+                type: "varchar(50)",
+                unicode: false,
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "HttpDisableAsyncPattern",
+                schema: "app",
+                table: "Step",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpHeaders",
+                schema: "app",
+                table: "Step",
+                type: "varchar(max)",
+                unicode: false,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpMethod",
+                schema: "app",
+                table: "Step",
+                type: "varchar(50)",
+                unicode: false,
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpUrl",
+                schema: "app",
+                table: "Step",
+                type: "varchar(2048)",
+                unicode: false,
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpBody",
+                schema: "app",
+                table: "ExecutionStep",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "HttpDisableAsyncPattern",
+                schema: "app",
+                table: "ExecutionStep",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpHeaders",
+                schema: "app",
+                table: "ExecutionStep",
+                type: "varchar(max)",
+                unicode: false,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpMethod",
+                schema: "app",
+                table: "ExecutionStep",
+                type: "varchar(50)",
+                unicode: false,
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HttpUrl",
+                schema: "app",
+                table: "ExecutionStep",
+                type: "varchar(2048)",
+                unicode: false,
+                maxLength: 2048,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HttpBody",
+                schema: "app",
+                table: "Step");
+
+            migrationBuilder.DropColumn(
+                name: "HttpBodyFormat",
+                schema: "app",
+                table: "Step");
+
+            migrationBuilder.DropColumn(
+                name: "HttpDisableAsyncPattern",
+                schema: "app",
+                table: "Step");
+
+            migrationBuilder.DropColumn(
+                name: "HttpHeaders",
+                schema: "app",
+                table: "Step");
+
+            migrationBuilder.DropColumn(
+                name: "HttpMethod",
+                schema: "app",
+                table: "Step");
+
+            migrationBuilder.DropColumn(
+                name: "HttpUrl",
+                schema: "app",
+                table: "Step");
+
+            migrationBuilder.DropColumn(
+                name: "HttpBody",
+                schema: "app",
+                table: "ExecutionStep");
+
+            migrationBuilder.DropColumn(
+                name: "HttpDisableAsyncPattern",
+                schema: "app",
+                table: "ExecutionStep");
+
+            migrationBuilder.DropColumn(
+                name: "HttpHeaders",
+                schema: "app",
+                table: "ExecutionStep");
+
+            migrationBuilder.DropColumn(
+                name: "HttpMethod",
+                schema: "app",
+                table: "ExecutionStep");
+
+            migrationBuilder.DropColumn(
+                name: "HttpUrl",
+                schema: "app",
+                table: "ExecutionStep");
+        }
+    }
+}

--- a/src/Biflow.Executor.Core/StepExecutor/HttpStepExecutor.cs
+++ b/src/Biflow.Executor.Core/StepExecutor/HttpStepExecutor.cs
@@ -1,0 +1,205 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Graph;
+
+namespace Biflow.Executor.Core.StepExecutor;
+
+[UsedImplicitly]
+internal class HttpStepExecutor(
+    ILogger<HttpStepExecutor> logger,
+    IDbContextFactory<ExecutorDbContext> dbContextFactory,
+    IOptionsMonitor<ExecutionOptions> options,
+    IHttpClientFactory httpClientFactory)
+    : StepExecutor<HttpStepExecution, HttpStepExecutionAttempt>(logger, dbContextFactory)
+{
+    private readonly int _pollingIntervalMs = options.CurrentValue.PollingIntervalMs;
+
+    private static readonly string[] ContentHeaders =
+    [
+        "Content-Type",
+        "Content-Length",
+        "Content-Encoding",
+        "Content-Language",
+        "Content-Location",
+        "Content-Disposition",
+        "Content-Range",
+        "Expires",
+        "Last-Modified"
+    ];
+    
+    protected override async Task<Result> ExecuteAsync(
+        OrchestrationContext context,
+        HttpStepExecution step,
+        HttpStepExecutionAttempt attempt,
+        ExtendedCancellationTokenSource cancellationTokenSource)
+    {
+        var cancellationToken = cancellationTokenSource.Token;
+        cancellationToken.ThrowIfCancellationRequested();
+        
+        using var timeoutCts = step.TimeoutMinutes > 0
+            ? new CancellationTokenSource(TimeSpan.FromMinutes(step.TimeoutMinutes))
+            : new CancellationTokenSource();
+
+        // The linked timeout token will cancel if the timeout expires or the step was canceled manually.
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        
+        // Use an HttpClient with no timeout.
+        // The step timeout setting is used for request timeout via cancellation token. 
+        var noTimeoutClient = httpClientFactory.CreateClient("notimeout");
+        
+        HttpResponseMessage? response = null;
+        try
+        {
+            using var request = BuildRequest(step, attempt);
+            response = await noTimeoutClient.SendAsync(request, linkedCts.Token);
+            attempt.AddOutput($"Response status code: {(int)response.StatusCode} {response.StatusCode}");
+            var content = await response.Content.ReadAsStringAsync(CancellationToken.None);
+            if (!string.IsNullOrEmpty(content))
+                attempt.AddOutput($"Response content:\n{content}");
+        }
+        catch (OperationCanceledException ex)
+        {
+            response?.Dispose();
+            if (timeoutCts.IsCancellationRequested)
+            {
+                attempt.AddError(ex, "Step execution timed out");
+                return Result.Failure;
+            }
+            attempt.AddWarning(ex);
+            return Result.Cancel;
+        }
+        catch (Exception ex)
+        {
+            response?.Dispose();
+            attempt.AddError(ex, "Error building/sending HTTP request");
+            return Result.Failure;
+        }
+
+        try
+        {
+            response.EnsureSuccessStatusCode();
+        }
+        catch (Exception ex)
+        {
+            response.Dispose();
+            attempt.AddError(ex, "HTTP response reported error status code");
+            return Result.Failure;
+        }
+
+        if (step.DisableAsyncPattern)
+        {
+            response.Dispose();
+            return Result.Success;
+        }
+        
+        try
+        {
+            return await PollAsyncPatternAsync(attempt, noTimeoutClient, response, linkedCts.Token);
+        }
+        catch (Exception ex)
+        {
+            attempt.AddError(ex, "Error polling for async pattern");
+            return Result.Failure;
+        }
+        finally
+        {
+            response.Dispose();
+        }
+    }
+
+    private static HttpRequestMessage BuildRequest(
+        HttpStepExecution step,
+        HttpStepExecutionAttempt attempt)
+    {
+        var method = step.Method switch
+        {
+            HttpStepMethod.Get => HttpMethod.Get,
+            HttpStepMethod.Post => HttpMethod.Post,
+            HttpStepMethod.Put => HttpMethod.Put,
+            HttpStepMethod.Delete => HttpMethod.Delete,
+            HttpStepMethod.Patch => HttpMethod.Patch,
+            _ => throw new ArgumentOutOfRangeException($"Unhandled HTTP method: {step.Method}")
+        };
+        var parameters = step.StepExecutionParameters.ToStringDictionary();
+        var url = step.Url.Replace(parameters);
+        // Only log the evaluated URL if it differs from the original URL. 
+        if (url != step.Url) attempt.AddOutput($"Evaluated URL:\n{url}");
+        var message = new HttpRequestMessage(method, url);
+
+        var headers = step.Headers
+            .Select(h => new HttpHeader(h.Key, h.Value.Replace(parameters)))
+            .ToArray();
+        // Only log the evaluated headers if they differ from the original headers.
+        if (headers.Length > 0 && headers.Any(h1 => step.Headers.Any(h2 => h1.Key == h2.Key && h1.Value != h2.Value)))
+        {
+            var headersAsText = string.Join("\n", headers.Select(h => $"{h.Key}: {h.Value}"));
+            attempt.AddOutput($"Evaluated headers:\n{headersAsText}");
+        }
+        // Exclude content headers from the request message headers.
+        foreach (var header in headers.Where(h => !ContentHeaders.Contains(h.Key)))
+        {
+            message.Headers.Add(header.Key, header.Value);
+        }
+        
+        // If a request body was defined, add it to the request content.
+        var input = step.Body?.Replace(parameters);
+        if (input != step.Body) attempt.AddOutput($"Evaluated request body:\n{input}");
+        var bytes = Encoding.UTF8.GetBytes(input ?? string.Empty);
+        // Use ByteArrayContent since it doesn't have a Content-Type header.
+        message.Content = new ByteArrayContent(bytes);
+        // Only include content headers in the request message content headers.
+        foreach (var header in headers.Where(h => ContentHeaders.Contains(h.Key)))
+        {
+            message.Content.Headers.Add(header.Key, header.Value);
+        }
+        return message;
+    }
+
+    private async Task<Result> PollAsyncPatternAsync(
+        HttpStepExecutionAttempt attempt,
+        HttpClient client,
+        HttpResponseMessage initialResponse,
+        CancellationToken cancellationToken)
+    {
+        if (initialResponse.StatusCode != HttpStatusCode.Accepted ||
+            initialResponse.Headers.Location is not { AbsoluteUri: { Length: > 0 } url })
+        {
+            return Result.Success;
+        }
+
+        attempt.AddOutput($"Polling URL:\n{url}");
+        using var response = await PollAndGetResponseAsync(client, url, cancellationToken);
+        
+        attempt.AddOutput($"Final polling response status code: {(int)response.StatusCode} {response.StatusCode}");
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!string.IsNullOrEmpty(content))
+        {
+            attempt.AddOutput($"Final polling response content:\n{content}");
+        }
+
+        if (response.IsSuccessStatusCode)
+        {
+            return Result.Success;
+        }
+        
+        attempt.AddError("Polling response reported error status code");
+        return Result.Failure;
+    }
+    
+    private async Task<HttpResponseMessage> PollAndGetResponseAsync(
+        HttpClient client,
+        string url,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            await Task.Delay(_pollingIntervalMs, cancellationToken);
+            var response = await client.GetAsync(url, cancellationToken);
+            if (response.StatusCode != HttpStatusCode.Accepted)
+                return response;
+            response.Dispose();
+        }
+    }
+}

--- a/src/Biflow.Ui.Api/Endpoints/StepsUpdateEndpoints.cs
+++ b/src/Biflow.Ui.Api/Endpoints/StepsUpdateEndpoints.cs
@@ -520,6 +520,70 @@ public abstract class StepsUpdateEndpoints : IEndpoints
                              "Use an empty string to clear the functionKey property.")
             .WithName("UpdateFunctionStep");
         
+        group.MapPut("/steps/http/{stepId:guid}", async (Guid stepId, HttpStepDto stepDto,
+            IMediator mediator, CancellationToken cancellationToken) =>
+            {
+                var dependencies = stepDto.Dependencies.ToDictionary(
+                    key => key.DependentOnStepId,
+                    value => value.DependencyType);
+                var executionConditionParameters = stepDto.ExecutionConditionParameters
+                    .Select(p => new UpdateExecutionConditionParameter(
+                        p.ParameterId,
+                        p.ParameterName,
+                        p.ParameterValue,
+                        p.InheritFromJobParameterId))
+                    .ToArray();
+                var parameters = stepDto.Parameters
+                    .Select(p => new UpdateStepParameter(
+                        p.ParameterId,
+                        p.ParameterName,
+                        p.ParameterValue,
+                        p.UseExpression,
+                        p.Expression,
+                        p.InheritFromJobParameterId,
+                        p.ExpressionParameters
+                            .Select(e => new UpdateExpressionParameter(e.ParameterId, e.ParameterName, e.InheritFromJobParameterId))
+                            .ToArray()))
+                    .ToArray();
+                var command = new UpdateHttpStepCommand
+                {
+                    StepId = stepId,
+                    StepName = stepDto.StepName,
+                    StepDescription = stepDto.StepDescription,
+                    ExecutionPhase = stepDto.ExecutionPhase,
+                    DuplicateExecutionBehaviour = stepDto.DuplicateExecutionBehaviour,
+                    IsEnabled = stepDto.IsEnabled,
+                    RetryAttempts = stepDto.RetryAttempts,
+                    RetryIntervalMinutes = stepDto.RetryIntervalMinutes,
+                    ExecutionConditionExpression = stepDto.ExecutionConditionExpression,
+                    StepTagIds = stepDto.StepTagIds,
+                    TimeoutMinutes = stepDto.TimeoutMinutes,
+                    Url = stepDto.Url,
+                    Method = stepDto.Method,
+                    Body = stepDto.Body,
+                    BodyFormat = stepDto.BodyFormat,
+                    Headers = stepDto.Headers,
+                    DisableAsyncPattern = stepDto.DisableAsyncPattern,
+                    Parameters = parameters,
+                    Dependencies = dependencies,
+                    ExecutionConditionParameters = executionConditionParameters,
+                    Sources = stepDto.Sources
+                        .Select(x => new DataObjectRelation(x.DataObjectId, x.DataAttributes))
+                        .ToArray(),
+                    Targets = stepDto.Targets
+                        .Select(x => new DataObjectRelation(x.DataObjectId, x.DataAttributes))
+                        .ToArray()
+                };
+                var step = await mediator.SendAsync(command, cancellationToken);
+                return Results.Ok(step);
+            })
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesValidationProblem()
+            .Produces<HttpStep>()
+            .WithSummary("Update HTTP step")
+            .WithDescription("Update an existing HTTP request step.")
+            .WithName("UpdateHttpStep");
+        
         group.MapPut("/steps/job/{stepId:guid}", async (Guid stepId, JobStepDto stepDto,
             IMediator mediator, CancellationToken cancellationToken) =>
             {

--- a/src/Biflow.Ui.Api/Models/Step/HttpStepDto.cs
+++ b/src/Biflow.Ui.Api/Models/Step/HttpStepDto.cs
@@ -1,0 +1,14 @@
+namespace Biflow.Ui.Api.Models.Step;
+
+[PublicAPI]
+public record HttpStepDto : StepDto
+{
+    public required double TimeoutMinutes { get; init; }
+    public required string Url { get; init; }
+    public required HttpStepMethod Method { get; init; } = HttpStepMethod.Post;
+    public string? Body { get; init; }
+    public HttpBodyFormat BodyFormat { get; init; } = HttpBodyFormat.PlainText;
+    public HttpHeader[] Headers { get; init; } = [];
+    public bool DisableAsyncPattern { get; init; }
+    public StepParameterDto[] Parameters { get; init; } = [];
+}

--- a/src/Biflow.Ui.Core/Mediator/Commands/Step/CreateHttpStep.cs
+++ b/src/Biflow.Ui.Core/Mediator/Commands/Step/CreateHttpStep.cs
@@ -1,0 +1,67 @@
+namespace Biflow.Ui.Core;
+
+public class CreateHttpStepCommand : CreateStepCommand<HttpStep>
+{
+    public required double TimeoutMinutes { get; init; }
+    public required string Url { get; init; }
+    public required HttpStepMethod Method { get; init; }
+    public required string? Body { get; init; }
+    public required HttpBodyFormat BodyFormat { get; init; }
+    public required HttpHeader[] Headers { get; init; }
+    public required bool DisableAsyncPattern { get; init; }
+    public required CreateStepParameter[] Parameters { get; init; }
+}
+
+[UsedImplicitly]
+internal class CreateHttpStepCommandHandler(
+    IDbContextFactory<AppDbContext> dbContextFactory,
+    StepValidator validator)
+    : CreateStepCommandHandler<CreateHttpStepCommand, HttpStep>(dbContextFactory, validator)
+{
+    protected override Task<HttpStep> CreateStepAsync(
+        CreateHttpStepCommand request, AppDbContext dbContext, CancellationToken cancellationToken)
+    {
+        var step = new HttpStep
+        {
+            JobId = request.JobId,
+            StepName = request.StepName,
+            StepDescription = request.StepDescription,
+            ExecutionPhase = request.ExecutionPhase,
+            DuplicateExecutionBehaviour = request.DuplicateExecutionBehaviour,
+            IsEnabled = request.IsEnabled,
+            RetryAttempts = request.RetryAttempts,
+            RetryIntervalMinutes = request.RetryIntervalMinutes,
+            ExecutionConditionExpression = new EvaluationExpression
+                { Expression = request.ExecutionConditionExpression },
+
+            TimeoutMinutes = request.TimeoutMinutes,
+            Url = request.Url,
+            Method = request.Method,
+            Body = request.Body,
+            BodyFormat = request.BodyFormat,
+            Headers = request.Headers.ToList(),
+            DisableAsyncPattern = request.DisableAsyncPattern
+        };
+            
+        foreach (var createParameter in request.Parameters)
+        {
+            var parameter = new HttpStepParameter
+            {
+                ParameterName = createParameter.ParameterName,
+                ParameterValue = createParameter.ParameterValue,
+                UseExpression = createParameter.UseExpression,
+                Expression = new EvaluationExpression { Expression = createParameter.Expression },
+                InheritFromJobParameterId = createParameter.InheritFromJobParameterId
+            };
+            foreach (var createExpressionParameter in createParameter.ExpressionParameters)
+            {
+                parameter.AddExpressionParameter(
+                    createExpressionParameter.ParameterName,
+                    createExpressionParameter.InheritFromJobParameterId);
+            }
+            step.StepParameters.Add(parameter);
+        }
+
+        return Task.FromResult(step);
+    }
+}

--- a/src/Biflow.Ui.Core/Mediator/Commands/Step/UpdateHttpStep.cs
+++ b/src/Biflow.Ui.Core/Mediator/Commands/Step/UpdateHttpStep.cs
@@ -1,0 +1,63 @@
+namespace Biflow.Ui.Core;
+
+public class UpdateHttpStepCommand : UpdateStepCommand<HttpStep>
+{
+    public required double TimeoutMinutes { get; init; }
+    public required string Url { get; init; }
+    public required HttpStepMethod Method { get; init; }
+    public required string? Body { get; init; }
+    public required HttpBodyFormat BodyFormat { get; init; }
+    public required HttpHeader[] Headers { get; init; }
+    public required bool DisableAsyncPattern { get; init; }
+    public required UpdateStepParameter[] Parameters { get; init; }
+}
+
+[UsedImplicitly]
+internal class UpdateHttpStepCommandHandler(
+    IDbContextFactory<AppDbContext> dbContextFactory,
+    StepValidator validator
+) : UpdateStepCommandHandler<UpdateHttpStepCommand, HttpStep>(dbContextFactory, validator)
+{
+    protected override Task<HttpStep?> GetStepAsync(Guid stepId, AppDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        return dbContext.HttpSteps
+            .Include(step => step.StepParameters)
+            .ThenInclude(p => p.InheritFromJobParameter)
+            .Include(step => step.StepParameters)
+            .ThenInclude(p => p.ExpressionParameters)
+            .Include(step => step.Tags)
+            .Include(step => step.Dependencies)
+            .Include(step => step.DataObjects)
+            .ThenInclude(s => s.DataObject)
+            .Include(step => step.ExecutionConditionParameters)
+            .FirstOrDefaultAsync(step => step.StepId == stepId, cancellationToken);
+    }
+
+    protected override async Task UpdateTypeSpecificPropertiesAsync(HttpStep step, UpdateHttpStepCommand request,
+        AppDbContext dbContext, CancellationToken cancellationToken)
+    {
+        step.TimeoutMinutes = request.TimeoutMinutes;
+        step.Url = request.Url;
+        step.Method = request.Method;
+        step.Body = request.Body;
+        step.BodyFormat = request.BodyFormat;
+        step.Headers.Clear();
+        step.Headers.AddRange(request.Headers);
+        step.DisableAsyncPattern = request.DisableAsyncPattern;
+        
+        await SynchronizeParametersAsync<HttpStepParameter, UpdateStepParameter>(
+            step,
+            request.Parameters,
+            parameter => new HttpStepParameter
+            {
+                ParameterName = parameter.ParameterName,
+                ParameterValue = parameter.ParameterValue,
+                UseExpression = parameter.UseExpression,
+                Expression = new EvaluationExpression { Expression = parameter.Expression },
+                InheritFromJobParameterId = parameter.InheritFromJobParameterId
+            },
+            dbContext,
+            cancellationToken);
+    }
+}

--- a/src/Biflow.Ui.Core/Validation/StepValidator.cs
+++ b/src/Biflow.Ui.Core/Validation/StepValidator.cs
@@ -63,6 +63,7 @@ public class StepValidator : AsyncAbstractValidator<Step>
             v.Add(new DbtStepValidator());
             v.Add(new DatabricksStepValidator());
             v.Add(new FunctionStepValidator());
+            v.Add(new HttpStepValidator());
             v.Add(new ExeStepValidator());
         });
         When(step => step is IHasStepParameters, () =>
@@ -113,6 +114,16 @@ file class FunctionStepValidator : AbstractValidator<FunctionStep>
             .Must(step => step.FunctionAppId is not null || !string.IsNullOrEmpty(step.FunctionKey))
             .WithMessage("Either the function app or the function key property must be set");
     }
+}
+
+file class HttpStepValidator : AbstractValidator<HttpStep>
+{
+    public HttpStepValidator()
+    {
+        RuleFor(step => step.Headers)
+            .Must(headers => headers.Select(h => h.Key).Distinct().Count() == headers.Count)
+            .WithMessage("The header keys must be unique");
+    }   
 }
 
 file class TabularStepValidator : AbstractValidator<TabularStep>

--- a/src/Biflow.Ui/Shared/Executions/StepExecutionDetails.razor
+++ b/src/Biflow.Ui/Shared/Executions/StepExecutionDetails.razor
@@ -366,6 +366,38 @@
                     </dd>
                 }
                 break;
+            case HttpStepExecution http:
+                <dt class="col-sm-3">
+                    Url
+                </dt>
+                <dd class="col-sm-9">
+                    @http.Url
+                </dd>
+                <dt class="col-sm-3">
+                    Method
+                </dt>
+                <dd class="col-sm-9">
+                    @http.Method.ToString().ToUpper()
+                </dd>
+                <dt class="col-sm-3">
+                    Request body
+                </dt>
+                <dd class="col-sm-9">
+                    <pre><code>@http.Body</code></pre>
+                </dd>
+                <dt class="col-sm-3">
+                    Disable async pattern
+                </dt>
+                <dd class="col-sm-9">
+                    @http.DisableAsyncPattern
+                </dd>
+                <dt class="col-sm-3">
+                    Headers
+                </dt>
+                <dd class="col-sm-9">
+                    @string.Join("\n", http.Headers.Select(x => $"{x.Key}: {x.Value}"))
+                </dd>
+                break;
             case AgentJobStepExecution agent:
                 <dt class="col-sm-3">
                     Agent job name

--- a/src/Biflow.Ui/Shared/JobDetails/DependenciesGraph.razor
+++ b/src/Biflow.Ui/Shared/JobDetails/DependenciesGraph.razor
@@ -227,4 +227,5 @@
     <DatabricksStepEditModal @ref="_stepEditModals[StepType.Databricks]" OnStepSubmit="OnStepSubmit" />
     <DbtStepEditModal @ref="_stepEditModals[StepType.Dbt]" OnStepSubmit="OnStepSubmit" />
     <ScdStepEditModal @ref="_stepEditModals[StepType.Scd]" OnStepSubmit="OnStepSubmit" />
+    <HttpStepEditModal @ref="_stepEditModals[StepType.Http]" OnStepSubmit="OnStepSubmit" />
 </AuthorizeView>

--- a/src/Biflow.Ui/Shared/JobDetails/StepDetailsModal.razor
+++ b/src/Biflow.Ui/Shared/JobDetails/StepDetailsModal.razor
@@ -196,6 +196,38 @@
                                         <td>@function.FunctionAppId</td>
                                     </tr>
                                     break;
+                                case HttpStep http:
+                                    <dt class="col-sm-3">
+                                        Url
+                                    </dt>
+                                    <dd class="col-sm-9">
+                                        @http.Url
+                                    </dd>
+                                    <dt class="col-sm-3">
+                                        Method
+                                    </dt>
+                                    <dd class="col-sm-9">
+                                        @http.Method.ToString().ToUpper()
+                                    </dd>
+                                    <dt class="col-sm-3">
+                                        Request body
+                                    </dt>
+                                    <dd class="col-sm-9">
+                                        <pre><code>@http.Body</code></pre>
+                                    </dd>
+                                    <dt class="col-sm-3">
+                                        Disable async pattern
+                                    </dt>
+                                    <dd class="col-sm-9">
+                                        @http.DisableAsyncPattern
+                                    </dd>
+                                    <dt class="col-sm-3">
+                                        Headers
+                                    </dt>
+                                    <dd class="col-sm-9">
+                                        @string.Join("\n", http.Headers.Select(x => $"{x.Key}: {x.Value}"))
+                                    </dd>
+                                    break;
                                 case AgentJobStep agent:
                                     <tr>
                                         <td>Agent job name</td>

--- a/src/Biflow.Ui/Shared/JobDetails/StepsList.razor
+++ b/src/Biflow.Ui/Shared/JobDetails/StepsList.razor
@@ -11,7 +11,7 @@
                             Add step
                         </HxDropdownToggleButton>
                         <HxDropdownMenu>
-                            <div class="px-3 g-3" style="min-width: 32rem;">
+                            <div class="px-3 g-3" style="min-width: 40rem;">
                                 @{
                                     var stepTypes = Enum.GetValues<StepType>()
                                         .GroupBy(t => t.GetCategory())
@@ -646,6 +646,7 @@
     <DatabricksStepEditModal @ref="_stepEditModals[StepType.Databricks]" OnStepSubmit="OnStepSubmit" />
     <DbtStepEditModal @ref="_stepEditModals[StepType.Dbt]" OnStepSubmit="OnStepSubmit" />
     <ScdStepEditModal @ref="_stepEditModals[StepType.Scd]" OnStepSubmit="OnStepSubmit" />
+    <HttpStepEditModal @ref="_stepEditModals[StepType.Http]" OnStepSubmit="OnStepSubmit" />
 </AuthorizeView>
 
 @{

--- a/src/Biflow.Ui/Shared/StepEditModal/HttpStepEditModal.razor
+++ b/src/Biflow.Ui/Shared/StepEditModal/HttpStepEditModal.razor
@@ -1,0 +1,167 @@
+@inherits StepEditModal<HttpStep>
+
+<StepEditModalTemplate Modal="this" TStep="HttpStep">
+    @if (Step is not null)
+    {
+        <div class="row">
+            <div class="col-md-4 d-md-flex justify-content-end">
+                <label class="form-label mb-lg-0">Timeout (min)</label>
+            </div>
+            <div class="col-md-6">
+                <div class="input-group input-group-sm">
+                    <div class="input-group-text">
+                        <SvgIcon Icon="LucideIcon.OctagonX" />
+                    </div>
+                    <InputNumber class="form-control form-control-sm"
+                                 @bind-Value="Step.TimeoutMinutes"
+                                 style="max-width: 5rem;"></InputNumber>
+                </div>
+                <span class="form-text">0 = indefinite</span>
+            </div>
+        </div>
+
+        <div class="row mt-3">
+            <div class="col-md-4 d-md-flex justify-content-end">
+                <label class="form-label mb-lg-0">URL</label>
+            </div>
+            <div class="col-md-6">
+                <div class="input-group input-group-sm">
+                    <div class="input-group-text">
+                        <SvgIcon Icon="LucideIcon.Globe" />
+                    </div>
+                    <InputTextArea class="form-control form-control-sm" rows="3" @bind-Value="Step.Url"></InputTextArea>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-3">
+            <div class="col-md-4 d-md-flex align-items-center justify-content-end">
+                <label class="form-label mb-lg-0">
+                    HTTP method
+                </label>
+            </div>
+            <div class="col-md-6">
+                <InputSelect class="form-select form-select-sm" @bind-Value="Step.Method" style="max-width: 8rem;">
+                    @foreach (var type in Enum.GetValues<HttpStepMethod>())
+                    {
+                        <option value="@type">@type.ToString().ToUpper()</option>
+                    }
+                </InputSelect>
+            </div>
+        </div>
+        
+        <div class="row mt-3">
+            <div class="col-md-4 d-md-flex justify-content-end">
+                <label class="form-check-label mb-lg-0"
+                       for="disable_async_pattern">
+                    Disable async pattern
+                    <HxPopover Trigger="PopoverTrigger.Hover" Html Content="@DisableAsyncPatternInfoContent">
+                        <SvgIcon Icon="LucideIcon.Info" />
+                    </HxPopover>
+                </label>
+            </div>
+            <div class="col-md-6">
+                <div class="form-check form-check-inline">
+                    <input type="checkbox" class="form-check-input" id="disable_async_pattern"
+                           checked=@Step.DisableAsyncPattern
+                           @bind-value="Step.DisableAsyncPattern">
+                </div>
+            </div>
+        </div>
+        
+        <div class="row justify-content-center mt-3">
+            <div class="col-md-9">
+                <label class="form-label">Request headers</label>
+                <table class="table table-sm">
+                    <tbody>
+                    @if (Step.Headers.Count == 0)
+                    {
+                        <tr>
+                            <td class="small text-muted">No headers</td>
+                        </tr>
+                    }
+                    else
+                    {
+                        foreach (var header in Step.Headers)
+                        {
+                            <tr>
+                                <td>
+                                    <InputText class="form-control form-control-sm"
+                                               @bind-Value="header.Key"
+                                               placeholder="Key" />
+                                </td>
+                                <td>
+                                    <InputText class="form-control form-control-sm"
+                                               @bind-Value="header.Value"
+                                               placeholder="Value" />
+                                </td>
+                                <td>
+                                    <HxButtonGroup Size="ButtonGroupSize.Small">
+                                        <HxButton Color="ThemeColor.None"
+                                                  CssClass="btn-auto"
+                                                  Size="ButtonSize.Small"
+                                                  @onclick="() => Step.Headers.Remove(header)">
+                                            <SvgIcon Icon="LucideIcon.Delete" />
+                                        </HxButton>
+                                    </HxButtonGroup>
+                                </td>
+                            </tr>
+                        }
+                    }
+                    </tbody>
+                </table>
+                <HxButtonGroup Size="ButtonGroupSize.Small">
+                    <HxButton Color="ThemeColor.None"
+                              CssClass="btn-auto"
+                              Size="ButtonSize.Small"
+                              @onclick="() => Step.Headers.Add(new HttpHeader())">
+                        <SvgIcon Icon="LucideIcon.Plus" />
+                        Add header
+                    </HxButton>
+                </HxButtonGroup>
+            </div>
+        </div>
+
+        <div class="row justify-content-center mt-3">
+            <div class="col-md-9">
+                <label class="form-label">Request body</label>
+            </div>
+        </div>
+        <div class="row justify-content-center">
+            <div class="col-md-9">
+                <CodeEditor @ref="_editor"
+                            Language="@(Step.BodyFormat == HttpBodyFormat.Json ? "json" : "")"
+                            MinimapEnabled="false"
+                            InitialValueExpression="() => Step.Body"
+                            OnValueChanged="value => Step.Body = value"
+                            Resize="CodeEditor.CodeEditorResize.Both" />
+            </div>
+        </div>
+
+        <div class="row mt-3">
+            <div class="col-md-4 d-md-flex justify-content-end">
+                <label class="form-check-label mb-lg-0">Body format</label>
+            </div>
+            <div class="col-md-6">
+                <div class="form-check form-check-inline">
+                    <input type="radio" class="form-check-input" id="radio_request_body_raw"
+                           checked=@(Step.BodyFormat == HttpBodyFormat.PlainText)
+                           @onchange="() => SetLanguageAsync(HttpBodyFormat.PlainText)">
+                    <label class="form-check-label fw-normal" for="radio_request_body_raw">Plain text</label>
+                </div>
+                <div class="form-check form-check-inline">
+                    <input type="radio" class="form-check-input" id="radio_request_body_json"
+                           checked=@(Step.BodyFormat == HttpBodyFormat.Json)
+                           @onchange="() => SetLanguageAsync(HttpBodyFormat.Json)">
+                    <label class="form-check-label fw-normal" for="radio_request_body_json">JSON</label>
+                </div>
+            </div>
+        </div>
+        
+        
+        <StepParametersEditor Step="Step" 
+                              NewParameterDelegate="() => new() { Step = Step }"
+                              Title="Parameters"
+                              InfoContent="@ParametersInfoContent" />
+    }
+</StepEditModalTemplate>

--- a/src/Biflow.Ui/Shared/StepEditModal/HttpStepEditModal.razor.cs
+++ b/src/Biflow.Ui/Shared/StepEditModal/HttpStepEditModal.razor.cs
@@ -1,0 +1,197 @@
+namespace Biflow.Ui.Shared.StepEditModal;
+
+public partial class HttpStepEditModal(
+    IMediator mediator,
+    ToasterService toaster,
+    IDbContextFactory<AppDbContext> dbContextFactory)
+    : StepEditModal<HttpStep>(mediator, toaster, dbContextFactory)
+{
+    internal override string FormId => "http_step_edit_form";
+    
+    private const string DisableAsyncPatternInfoContent = """
+        <div>
+            Option to disable invoking HTTP GET on location given in response header of a HTTP 202 Response.
+            If set true, it stops invoking HTTP GET on http location given in response header.
+            If set false then continues to invoke HTTP GET call on location given in http response headers.
+        </div>
+        """;
+
+    private const string ParametersInfoContent = """
+        <div>
+            <p>Use parameters to dynamically pass values to the URL, header values and request body.</p>
+            <p>
+                Parameters are matched based on their names. For example, say you have defined a parameter named <code>@ModifiedSince</code> with a value of <code>2024-09-01</code>.
+                A request body like <code>{ "ModifiedSince": "@ModifiedSince" }</code> will become <code>{ "ModifiedSince": "2024-09-01" }</code>
+            </p>
+        </div>
+        """;
+    
+    private CodeEditor? _editor;
+    
+    protected override Task<HttpStep> GetExistingStepAsync(AppDbContext context, Guid stepId) =>
+        context.HttpSteps
+            .Include(step => step.Job)
+            .ThenInclude(job => job.JobParameters)
+            .Include(step => step.StepParameters)
+            .ThenInclude(p => p.InheritFromJobParameter)
+            .Include(step => step.StepParameters)
+            .ThenInclude(p => p.ExpressionParameters)
+            .Include(step => step.Tags)
+            .Include(step => step.Dependencies)
+            .Include(step => step.DataObjects)
+            .ThenInclude(s => s.DataObject)
+            .Include(step => step.ExecutionConditionParameters)
+            .FirstAsync(step => step.StepId == stepId);
+
+    protected override HttpStep CreateNewStep(Job job) =>
+        new()
+        {
+            JobId = job.JobId,
+            Job = job,
+            RetryAttempts = 0,
+            RetryIntervalMinutes = 0
+        };
+    
+    protected override async Task<HttpStep> OnSubmitCreateAsync(HttpStep step)
+    {
+        var dependencies = step.Dependencies.ToDictionary(
+            key => key.DependantOnStepId,
+            value => value.DependencyType);
+        var executionConditionParameters = step.ExecutionConditionParameters
+            .Select(p => new CreateExecutionConditionParameter(
+                p.ParameterName,
+                p.ParameterValue,
+                p.JobParameterId))
+            .ToArray();
+        var parameters = step.StepParameters
+            .Select(p => new CreateStepParameter(
+                p.ParameterName,
+                p.ParameterValue,
+                p.UseExpression,
+                p.Expression.Expression,
+                p.InheritFromJobParameterId,
+                p.ExpressionParameters
+                    .Select(e => new CreateExpressionParameter(e.ParameterName, e.InheritFromJobParameterId))
+                    .ToArray()))
+            .ToArray();
+        var command = new CreateHttpStepCommand
+        {
+            JobId = step.JobId,
+            StepName = step.StepName ?? "",
+            StepDescription = step.StepDescription,
+            ExecutionPhase = step.ExecutionPhase,
+            DuplicateExecutionBehaviour = step.DuplicateExecutionBehaviour,
+            IsEnabled = step.IsEnabled,
+            RetryAttempts = step.RetryAttempts,
+            RetryIntervalMinutes = step.RetryIntervalMinutes,
+            ExecutionConditionExpression = step.ExecutionConditionExpression.Expression,
+            StepTagIds = step.Tags.Select(t => t.TagId).ToArray(),
+            TimeoutMinutes = step.TimeoutMinutes,
+            Url = step.Url,
+            Method = step.Method,
+            Body = step.Body,
+            BodyFormat = step.BodyFormat,
+            Headers = step.Headers.ToArray(),
+            DisableAsyncPattern = step.DisableAsyncPattern,
+            Dependencies = dependencies,
+            ExecutionConditionParameters = executionConditionParameters,
+            Sources = step.DataObjects
+                .Where(x => x.ReferenceType == DataObjectReferenceType.Source)
+                .Select(x => new DataObjectRelation(x.DataObject.ObjectId, x.DataAttributes.ToArray()))
+                .ToArray(),
+            Targets = step.DataObjects
+                .Where(x => x.ReferenceType == DataObjectReferenceType.Target)
+                .Select(x => new DataObjectRelation(x.DataObject.ObjectId, x.DataAttributes.ToArray()))
+                .ToArray(),
+            Parameters = parameters
+        };
+        return await Mediator.SendAsync(command);
+    }
+
+    protected override async Task<HttpStep> OnSubmitUpdateAsync(HttpStep step)
+    {
+        var dependencies = step.Dependencies.ToDictionary(
+            key => key.DependantOnStepId,
+            value => value.DependencyType);
+        var executionConditionParameters = step.ExecutionConditionParameters
+            .Select(p => new UpdateExecutionConditionParameter(
+                p.ParameterId,
+                p.ParameterName,
+                p.ParameterValue,
+                p.JobParameterId))
+            .ToArray();
+        var parameters = step.StepParameters
+            .Select(p => new UpdateStepParameter(
+                p.ParameterId,
+                p.ParameterName,
+                p.ParameterValue,
+                p.UseExpression,
+                p.Expression.Expression,
+                p.InheritFromJobParameterId,
+                p.ExpressionParameters
+                    .Select(e => new UpdateExpressionParameter(
+                        e.ParameterId,
+                        e.ParameterName,
+                        e.InheritFromJobParameterId))
+                    .ToArray()))
+            .ToArray();
+        var command = new UpdateHttpStepCommand
+        {
+            StepId = step.StepId,
+            StepName = step.StepName ?? "",
+            StepDescription = step.StepDescription,
+            ExecutionPhase = step.ExecutionPhase,
+            DuplicateExecutionBehaviour = step.DuplicateExecutionBehaviour,
+            IsEnabled = step.IsEnabled,
+            RetryAttempts = step.RetryAttempts,
+            RetryIntervalMinutes = step.RetryIntervalMinutes,
+            ExecutionConditionExpression = step.ExecutionConditionExpression.Expression,
+            StepTagIds = step.Tags.Select(t => t.TagId).ToArray(),
+            TimeoutMinutes = step.TimeoutMinutes,
+            Url = step.Url,
+            Method = step.Method,
+            Body = step.Body,
+            BodyFormat = step.BodyFormat,
+            Headers = step.Headers.ToArray(),
+            DisableAsyncPattern = step.DisableAsyncPattern,
+            Dependencies = dependencies,
+            ExecutionConditionParameters = executionConditionParameters,
+            Sources = step.DataObjects
+                .Where(x => x.ReferenceType == DataObjectReferenceType.Source)
+                .Select(x => new DataObjectRelation(x.DataObject.ObjectId, x.DataAttributes.ToArray()))
+                .ToArray(),
+            Targets = step.DataObjects
+                .Where(x => x.ReferenceType == DataObjectReferenceType.Target)
+                .Select(x => new DataObjectRelation(x.DataObject.ObjectId, x.DataAttributes.ToArray()))
+                .ToArray(),
+            Parameters = parameters
+        };
+        return await Mediator.SendAsync(command);
+    }
+    
+    protected override async Task OnModalShownAsync(HttpStep step)
+    {
+        if (_editor is not null)
+        {
+            try
+            {
+                await _editor.SetValueAsync(step.Body);
+            }
+            catch { /* ignored */ }
+        }
+    }
+
+    private Task SetLanguageAsync(HttpBodyFormat language)
+    {
+        ArgumentNullException.ThrowIfNull(Step);
+        Step.BodyFormat = language;
+        ArgumentNullException.ThrowIfNull(_editor);
+        var inputLanguage = language switch
+        {
+            HttpBodyFormat.Json => "json",
+            _ => ""
+        };
+        return _editor.SetLanguageAsync(inputLanguage);
+    }
+    
+}

--- a/src/Biflow.Ui/Shared/StepTypeIcon.razor
+++ b/src/Biflow.Ui/Shared/StepTypeIcon.razor
@@ -50,6 +50,9 @@
     case ST.Scd:
         <SvgIcon Icon="LucideIcon.Replace" />
         break;
+    case ST.Http:
+        <SvgIcon Icon="LucideIcon.Globe" />
+        break;
     default:
         <SvgIcon Icon="LucideIcon.CircleX" />
         break;


### PR DESCRIPTION
Adds support for running arbitrary HTTP requests as part of workflows.

HTTP step allows the user to set the request's
- URL
- HTTP method
- headers
- content

The HTTP step also by default handles async patterns, which are used, for example, with [Azure durable functions](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-http-api#start-orchestration).

The URL, header values and content support step parameters.