### PR TITLE
Fix SCD MD5 hash calculation when only one column is provided

### DIFF
--- a/src/Biflow.Core/Entities/Scd/ISqlSyntaxProvider.cs
+++ b/src/Biflow.Core/Entities/Scd/ISqlSyntaxProvider.cs
@@ -44,7 +44,7 @@ internal interface ISqlFunctionProvider
     public string CurrentTimestamp { get; }
     public string MaxDateTime { get; }
     public string True { get; }
-    public string Md5(IEnumerable<string> columns);
+    public string Md5(IReadOnlyList<string> columns);
 }
 
 internal interface ISqlIndexProvider

--- a/src/Biflow.Core/Entities/Scd/MsSql/MsSqlSyntaxProvider.cs
+++ b/src/Biflow.Core/Entities/Scd/MsSql/MsSqlSyntaxProvider.cs
@@ -20,8 +20,12 @@ internal sealed class MsSqlSyntaxProvider : ISqlSyntaxProvider
         public string CurrentTimestamp => "GETDATE()";
         public string MaxDateTime => "CONVERT(DATETIME2(6), '9999-12-31')";
         public string True => "1";
-        public string Md5(IEnumerable<string> columns) =>
-            $"CONVERT(VARCHAR(32), HASHBYTES('MD5', CONCAT({string.Join(", '|', ", columns.Select(c => c.QuoteName()))})), 2)";
+        public string Md5(IReadOnlyList<string> columns) => columns switch
+        {
+            [] => throw new ArgumentException("columns was empty. MD5 requires at least one columns.", nameof(columns)),
+            [var c] => $"CONVERT(VARCHAR(32), HASHBYTES('MD5', CONVERT(VARCHAR(MAX), {c.QuoteName()})), 2)",
+            _ => $"CONVERT(VARCHAR(32), HASHBYTES('MD5', CONCAT({string.Join(", '|', ", columns.Select(c => c.QuoteName()))})), 2)"
+        };
     }
 
     private class MsSqlIndexProvider : ISqlIndexProvider

--- a/src/Biflow.Core/Entities/Scd/ScdProvider.cs
+++ b/src/Biflow.Core/Entities/Scd/ScdProvider.cs
@@ -350,7 +350,8 @@ internal abstract class ScdProvider(ScdTable table, IColumnMetadataProvider colu
         
         IEnumerable<ILoadColumn> recordColumns = [..naturalKeyColumns, ..otherColumns];
         var quotedRecordColumns = recordColumns
-            .Select(c => c.ColumnName);
+            .Select(c => c.ColumnName)
+            .ToArray();
         var recordHashColumn = new LoadColumn
         {
             ColumnName = RecordHashColumn,

--- a/src/Biflow.Core/Entities/Scd/Snowflake/SnowflakeSyntaxProvider.cs
+++ b/src/Biflow.Core/Entities/Scd/Snowflake/SnowflakeSyntaxProvider.cs
@@ -22,8 +22,13 @@ internal sealed class SnowflakeSyntaxProvider : ISqlSyntaxProvider
         public string CurrentTimestamp => "CURRENT_TIMESTAMP";
         public string MaxDateTime => "CAST('9999-12-31' AS TIMESTAMP_NTZ)";
         public string True => "1";
-        public string Md5(IEnumerable<string> columns) =>
-            $"UPPER(MD5(CONCAT({string.Join(", '|', ", columns.Select(c => c.QuoteName()))})))";
+        public string Md5(IReadOnlyList<string> columns) => columns switch
+        {
+            [] => throw new ArgumentException("columns was empty. MD5 requires at least one columns.", nameof(columns)),
+            [var c] => $"UPPER(MD5(TO_VARCHAR({c.QuoteName()})))",
+            _ => $"UPPER(MD5(CONCAT({string.Join(", '|', ", columns.Select(c => c.QuoteName()))})))"
+        };
+
     }
 
     private class SnowflakeIndexProvider : ISqlIndexProvider


### PR DESCRIPTION
The MD5 hash calculation in SCD SQL syntax providers now handles the case where only column is provided. In this case, `CONCAT()` cannot be used with just one column, but instead, the single column is simply cast to text.