### PR TITLE
Refactored FunctionStep FunctionIsDurable to DisableAsyncPattern

### DIFF
--- a/src/Biflow.Core/Entities/Step/Function/FunctionStep.cs
+++ b/src/Biflow.Core/Entities/Step/Function/FunctionStep.cs
@@ -18,7 +18,7 @@ public class FunctionStep : Step, IHasTimeout, IHasStepParameters<FunctionStepPa
         FunctionUrl = other.FunctionUrl;
         FunctionInput = other.FunctionInput;
         FunctionInputFormat = other.FunctionInputFormat;
-        FunctionIsDurable = other.FunctionIsDurable;
+        DisableAsyncPattern = other.DisableAsyncPattern;
         FunctionKey = other.FunctionKey;
         StepParameters = other.StepParameters
             .Select(p => new FunctionStepParameter(p, this, targetJob))
@@ -43,7 +43,12 @@ public class FunctionStep : Step, IHasTimeout, IHasStepParameters<FunctionStepPa
     
     public FunctionInputFormat FunctionInputFormat { get; set; } = FunctionInputFormat.PlainText;
 
-    public bool FunctionIsDurable { get; set; }
+    /// <summary>
+    /// Option to disable async polling of status for durable functions.
+    /// If enabled, the step will be completed immediately after the function has been successfully invoked.
+    /// This option has no effect when invoking non-durable functions.
+    /// </summary>
+    public bool DisableAsyncPattern { get; set; }
 
     [MaxLength(1000)]
     [JsonSensitive]

--- a/src/Biflow.Core/Entities/Step/Function/FunctionStepExecution.cs
+++ b/src/Biflow.Core/Entities/Step/Function/FunctionStepExecution.cs
@@ -20,7 +20,7 @@ public class FunctionStepExecution : StepExecution,
         FunctionAppId = step.FunctionAppId;
         FunctionUrl = step.FunctionUrl;
         FunctionInput = step.FunctionInput;
-        FunctionIsDurable = step.FunctionIsDurable;
+        DisableAsyncPattern = step.DisableAsyncPattern;
         TimeoutMinutes = step.TimeoutMinutes;
 
         StepExecutionParameters = step.StepParameters
@@ -36,7 +36,12 @@ public class FunctionStepExecution : StepExecution,
 
     public string? FunctionInput { get; private set; }
 
-    public bool FunctionIsDurable { get; private set; }
+    /// <summary>
+    /// Option to disable async polling of status for durable functions.
+    /// If enabled, the step will be completed immediately after the function has been successfully invoked.
+    /// This option has no effect when invoking non-durable functions.
+    /// </summary>
+    public bool DisableAsyncPattern { get; init; }
 
     public double TimeoutMinutes { get; [UsedImplicitly] private set; }
 

--- a/src/Biflow.DataAccess/Configuration/Step/Function/FunctionStepEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/Function/FunctionStepEntityTypeConfiguration.cs
@@ -5,6 +5,7 @@ internal class FunctionStepEntityTypeConfiguration : IEntityTypeConfiguration<Fu
     public void Configure(EntityTypeBuilder<FunctionStep> builder)
     {
         builder.Property(x => x.TimeoutMinutes).HasColumnName("TimeoutMinutes");
+        builder.Property(x => x.DisableAsyncPattern).HasColumnName("FunctionDisableAsyncPattern");
         builder.Property(x => x.FunctionUrl).IsUnicode(false);
     }
 }

--- a/src/Biflow.DataAccess/Configuration/Step/Function/FunctionStepExecutionEntityTypeConfiguration.cs
+++ b/src/Biflow.DataAccess/Configuration/Step/Function/FunctionStepExecutionEntityTypeConfiguration.cs
@@ -5,7 +5,7 @@ internal class FunctionStepExecutionEntityTypeConfiguration : IEntityTypeConfigu
     public void Configure(EntityTypeBuilder<FunctionStepExecution> builder)
     {
         builder.Property(x => x.TimeoutMinutes).HasColumnName("TimeoutMinutes");
-
+        builder.Property(x => x.DisableAsyncPattern).HasColumnName("FunctionDisableAsyncPattern");
         builder.Property(x => x.FunctionUrl).IsUnicode(false);
     }
 }

--- a/src/Biflow.DataAccess/Migrations/20251010095154_FunctionStepRefactor.Designer.cs
+++ b/src/Biflow.DataAccess/Migrations/20251010095154_FunctionStepRefactor.Designer.cs
@@ -5,6 +5,7 @@ using Biflow.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -12,9 +13,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Biflow.DataAccess.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251010095154_FunctionStepRefactor")]
+    partial class FunctionStepRefactor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Biflow.DataAccess/Migrations/20251010095154_FunctionStepRefactor.cs
+++ b/src/Biflow.DataAccess/Migrations/20251010095154_FunctionStepRefactor.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Biflow.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class FunctionStepRefactor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "FunctionIsDurable",
+                schema: "app",
+                table: "Step",
+                newName: "FunctionDisableAsyncPattern");
+
+            migrationBuilder.RenameColumn(
+                name: "FunctionIsDurable",
+                schema: "app",
+                table: "ExecutionStep",
+                newName: "FunctionDisableAsyncPattern");
+            
+            // Since the purpose and meaning of the property has changed somewhat, reset it to false.
+            // This is the safer option.
+            migrationBuilder.Sql("""
+                UPDATE app.Step
+                SET FunctionDisableAsyncPattern = 0
+                WHERE StepType = 'Function'
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "FunctionDisableAsyncPattern",
+                schema: "app",
+                table: "Step",
+                newName: "FunctionIsDurable");
+
+            migrationBuilder.RenameColumn(
+                name: "FunctionDisableAsyncPattern",
+                schema: "app",
+                table: "ExecutionStep",
+                newName: "FunctionIsDurable");
+            
+            migrationBuilder.Sql("""
+                UPDATE app.Step
+                SET FunctionIsDurable = 0
+                WHERE StepType = 'Function'
+                """);
+        }
+    }
+}

--- a/src/Biflow.Executor.Core/StepExecutor/FunctionStepExecutor.cs
+++ b/src/Biflow.Executor.Core/StepExecutor/FunctionStepExecutor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Net;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;
 using System.Text.Json;
@@ -13,9 +14,7 @@ internal class FunctionStepExecutor(
     IHttpClientFactory httpClientFactory)
     : StepExecutor<FunctionStepExecution, FunctionStepExecutionAttempt>(logger, dbContextFactory)
 {
-    private readonly ILogger<FunctionStepExecutor> _logger = logger;
     private readonly IDbContextFactory<ExecutorDbContext> _dbContextFactory = dbContextFactory;
-    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
     private readonly int _pollingIntervalMs = options.CurrentValue.PollingIntervalMs;
 
     private const int MaxRefreshRetries = 3;
@@ -30,7 +29,7 @@ internal class FunctionStepExecutor(
         PropertyNameCaseInsensitive = true
     };
 
-    protected override Task<Result> ExecuteAsync(
+    protected override async Task<Result> ExecuteAsync(
         OrchestrationContext context,
         FunctionStepExecution step,
         FunctionStepExecutionAttempt attempt,
@@ -38,85 +37,196 @@ internal class FunctionStepExecutor(
     {
         var cancellationToken = cancellationTokenSource.Token;
         cancellationToken.ThrowIfCancellationRequested();
-        return step switch
+        
+        using var timeoutCts = step.TimeoutMinutes > 0
+            ? new CancellationTokenSource(TimeSpan.FromMinutes(step.TimeoutMinutes))
+            : new CancellationTokenSource();
+
+        // The linked timeout token will cancel if the timeout expires or the step was canceled manually.
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        
+        // Use an HttpClient with no timeout.
+        // The step timeout setting is used for request timeout via cancellation token. 
+        var noTimeoutClient = httpClientFactory.CreateClient("notimeout");
+
+        HttpResponseMessage? response = null;
+        try
         {
-            { FunctionIsDurable: true } => RunDurableFunctionAsync(step, attempt, cancellationTokenSource),
-            _ => RunHttpFunctionAsync(step, attempt, cancellationToken)
-        };
+            string content;
+            try
+            {
+                using var request = await BuildFunctionInvokeRequestAsync(step, attempt, cancellationToken);
+
+                // Send the request to the function url. This will start the function if the request was successful.
+                // A durable function will return immediately and run asynchronously.
+                response = await noTimeoutClient.SendAsync(request, cancellationToken);
+                attempt.AddOutput($"Response status code: {(int)response.StatusCode} {response.StatusCode}");
+                content = await response.Content.ReadAsStringAsync(CancellationToken.None);
+                if (!string.IsNullOrEmpty(content))
+                {
+                    attempt.AddOutput($"Response content:\n{content}");
+                }
+            }
+            catch (OperationCanceledException ex)
+            {
+                if (cancellationTokenSource.IsCancellationRequested)
+                {
+                    attempt.AddWarning(ex);
+                    return Result.Cancel;
+                }
+
+                attempt.AddError(ex, "Invoking function timed out");
+                return Result.Failure;
+            }
+            catch (Exception ex)
+            {
+                attempt.AddError(ex, "Error building/sending POST request to invoke function");
+                return Result.Failure;
+            }
+
+            try
+            {
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                attempt.AddError(ex, "HTTP response reported error status code");
+                return Result.Failure;
+            }
+
+            if (step.DisableAsyncPattern)
+            {
+                return Result.Success;
+            }
+
+            try
+            {
+                return await PollAsyncPatternAsync(
+                    step: step,
+                    attempt: attempt,
+                    client: noTimeoutClient,
+                    initialResponse: response,
+                    initialContent: content,
+                    isTimeout: () => timeoutCts.IsCancellationRequested,
+                    cancellationToken: linkedCts.Token);
+            }
+            catch (Exception ex)
+            {
+                attempt.AddError(ex, "Error polling for async pattern");
+                return Result.Failure;
+            }
+        }
+        finally
+        {
+            response?.Dispose();
+        }
     }
 
-    private async Task<Result> RunDurableFunctionAsync(
+    private async Task<Result> PollAsyncPatternAsync(
         FunctionStepExecution step,
         FunctionStepExecutionAttempt attempt,
-        ExtendedCancellationTokenSource cancellationTokenSource)
+        HttpClient client,
+        HttpResponseMessage initialResponse,
+        string initialContent,
+        Func<bool> isTimeout,
+        CancellationToken cancellationToken)
     {
-        var cancellationToken = cancellationTokenSource.Token;
-        var client = _httpClientFactory.CreateClient();
+        if (initialResponse.StatusCode != HttpStatusCode.Accepted)
+        {
+            return Result.Success;
+        }
+        
+        var startResponse = JsonSerializer.Deserialize<StartResponse>(initialContent, CaseInsensitiveOptions);
+        if (startResponse is not null)
+        {
+            return await PollUsingStatusResponseAsync(
+                step, attempt, client, startResponse, isTimeout, cancellationToken);
+        }
+        
+        attempt.AddOutput("No status response object was returned from the function. "
+                          + "Polling for status using status codes instead.");
 
-        HttpResponseMessage response;
-        string content;
+        if (initialResponse.Headers.Location is { AbsoluteUri: { Length: > 0 } url })
+        {
+            return await PollUsingStatusCodesAsync(attempt, client, url, cancellationToken);
+        }
+        
+        attempt.AddWarning("No status response object or location header was returned from the function. "
+                           + "Skipped polling.");
+        return Result.Success;
+    }
+
+    private async Task<HttpRequestMessage> BuildFunctionInvokeRequestAsync(
+        FunctionStepExecution step,
+        FunctionStepExecutionAttempt attempt,
+        CancellationToken cancellationToken)
+    {
+        string? functionKey = null;
         try
         {
-            var request = await BuildFunctionInvokeRequestAsync(step, attempt, cancellationToken);
-
-            // Send the request to the function url. This will start the function, if the request was successful.
-            // A durable function will return immediately and run asynchronously.
-            response = await client.SendAsync(request, cancellationToken);
-            content = await response.Content.ReadAsStringAsync(CancellationToken.None);
-            if (!string.IsNullOrEmpty(content))
-            {
-                attempt.AddOutput($"Response:\n{content}");
-            }
-        }
-        catch (OperationCanceledException ex)
-        {
-            if (cancellationTokenSource.IsCancellationRequested)
-            {
-                attempt.AddWarning(ex);
-                return Result.Cancel;
-            }
-            attempt.AddError(ex, "Invoking durable function timed out");
-            return Result.Failure;
+            // Try and get the function key from the actual step if it was defined.
+            await using var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+            functionKey = await context.FunctionSteps
+                .AsNoTracking()
+                .Where(s => s.StepId == step.StepId)
+                .Select(s => s.FunctionKey)
+                .FirstOrDefaultAsync(cancellationToken);
         }
         catch (Exception ex)
         {
-            attempt.AddError(ex, "Error sending POST request to invoke function");
-            return Result.Failure;
+            logger.LogError(ex, "{ExecutionId} {Step} Error reading FunctionKey from database", step.ExecutionId, step);
+            attempt.AddWarning(ex, "Error reading function key from database");
         }
 
-        StartResponse startResponse;
-        try
+        var message = new HttpRequestMessage(HttpMethod.Post, step.FunctionUrl);
+
+        // Add function security code as a request header. If the function specific code was defined, use that.
+        // Otherwise, revert to the function app code if it was defined.
+        var functionApp = step.GetApp();
+
+        functionKey ??= functionApp?.FunctionAppKey;
+        
+        ArgumentException.ThrowIfNullOrEmpty(functionKey);
+
+        message.Headers.Add("x-functions-key", functionKey);
+        
+        if (string.IsNullOrEmpty(step.FunctionInput))
         {
-            response.EnsureSuccessStatusCode();
-            startResponse = JsonSerializer.Deserialize<StartResponse>(content, CaseInsensitiveOptions)
-                ?? throw new InvalidOperationException("Start response was null");
+            return message;
         }
-        catch (Exception ex)
-        {
-            attempt.AddError(ex, "Error getting start response for durable function");
-            return Result.Failure;
-        }
+        
+        // If the input for the function was defined, add it to the request content.
+        var parameters = step.StepExecutionParameters.ToStringDictionary();
+        var input = step.FunctionInput.Replace(parameters);
+        attempt.AddOutput($"Evaluated function input:\n{input}");
+        message.Content = new StringContent(input);
 
-        // Create timeout cancellation token source here
-        // so that the timeout countdown starts right after the function was started.
-        using var timeoutCts = step.TimeoutMinutes > 0
-                ? new CancellationTokenSource(TimeSpan.FromMinutes(step.TimeoutMinutes))
-                : new CancellationTokenSource();
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        return message;
+    }
 
+    private async Task<Result> PollUsingStatusResponseAsync(
+        FunctionStepExecution step,
+        FunctionStepExecutionAttempt attempt,
+        HttpClient client,
+        StartResponse startResponse,
+        Func<bool> isTimeout,
+        CancellationToken cancellationToken)
+    {
         // Update instance id for the step execution attempt
         try
         {
             await using var context = await _dbContextFactory.CreateDbContextAsync(CancellationToken.None);
             attempt.FunctionInstanceId = startResponse.Id;
             await context.Set<FunctionStepExecutionAttempt>()
-                .Where(x => x.ExecutionId == attempt.ExecutionId && x.StepId == attempt.StepId && x.RetryAttemptIndex == attempt.RetryAttemptIndex)
+                .Where(x => x.ExecutionId == attempt.ExecutionId &&
+                            x.StepId == attempt.StepId &&
+                            x.RetryAttemptIndex == attempt.RetryAttemptIndex)
                 .ExecuteUpdateAsync(x => x
                     .SetProperty(p => p.FunctionInstanceId, attempt.FunctionInstanceId), CancellationToken.None);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "{ExecutionId} {Step} Error updating function instance id", step.ExecutionId, step);
+            logger.LogWarning(ex, "{ExecutionId} {Step} Error updating function instance id", step.ExecutionId, step);
             attempt.AddWarning(ex, $"Error updating function instance id {startResponse.Id}");
         }
 
@@ -125,10 +235,14 @@ internal class FunctionStepExecutor(
         {
             try
             {
-                status = await GetStatusWithRetriesAsync(client, step, startResponse.StatusQueryGetUri, linkedCts.Token);
+                status = await GetStatusResponseWithRetriesAsync(
+                    step,
+                    client,
+                    startResponse.StatusQueryGetUri,
+                    cancellationToken);
                 if (status.RuntimeStatus is "Pending" or "Running" or "ContinuedAsNew")
                 {
-                    await Task.Delay(_pollingIntervalMs, linkedCts.Token);
+                    await Task.Delay(_pollingIntervalMs, cancellationToken);
                 }
                 else
                 {
@@ -137,9 +251,9 @@ internal class FunctionStepExecutor(
             }
             catch (OperationCanceledException ex)
             {
-                var reason = timeoutCts.IsCancellationRequested ? "StepTimedOut" : "StepWasCanceled";
+                var reason = isTimeout() ? "StepTimedOut" : "StepWasCanceled";
                 await CancelAsync(step, attempt, client, startResponse.TerminatePostUri, reason);
-                if (timeoutCts.IsCancellationRequested)
+                if (isTimeout())
                 {
                     attempt.AddError(ex, "Step execution timed out");
                     return Result.Failure;
@@ -172,110 +286,30 @@ internal class FunctionStepExecutor(
         }
     }
 
-    private async Task<Result> RunHttpFunctionAsync(
+    private async Task<StatusResponse> GetStatusResponseWithRetriesAsync(
         FunctionStepExecution step,
-        FunctionStepExecutionAttempt attempt,
+        HttpClient client,
+        string statusUrl,
         CancellationToken cancellationToken)
     {
-        using var timeoutCts = step.TimeoutMinutes > 0
-                    ? new CancellationTokenSource(TimeSpan.FromMinutes(step.TimeoutMinutes))
-                    : new CancellationTokenSource();
+        var policy = Policy
+            .Handle<Exception>()
+            .WaitAndRetryAsync(
+            retryCount: MaxRefreshRetries,
+            sleepDurationProvider: _ => TimeSpan.FromMilliseconds(_pollingIntervalMs),
+            onRetry: (ex, _) =>
+                logger.LogWarning(ex, "{ExecutionId} {Step} Error getting function instance status", step.ExecutionId, step));
 
-        HttpResponseMessage response;
-        try
+        return await policy.ExecuteAsync(async cancellation =>
         {
-            // The linked timeout token will cancel if the timeout expires or the step was canceled manually.
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
-
-            var request = await BuildFunctionInvokeRequestAsync(step, attempt, cancellationToken);
-
-            // A regular httpTrigger function can run for several minutes. Use an HttpClient with no timeout for httpTrigger functions.
-            var noTimeoutClient = _httpClientFactory.CreateClient("notimeout");
-
-            // Send the request to the function url. This will start the function, if the request was successful.
-            response = await noTimeoutClient.SendAsync(request, linkedCts.Token);
-            var content = await response.Content.ReadAsStringAsync(CancellationToken.None);
-            if (!string.IsNullOrEmpty(content))
-            {
-                attempt.AddOutput($"Response:\n{content}");
-            }
-        }
-        catch (OperationCanceledException ex)
-        {
-            if (timeoutCts.IsCancellationRequested)
-            {
-                attempt.AddError(ex, "Step execution timed out");
-                return Result.Failure;
-            }
-            attempt.AddWarning(ex);
-            return Result.Cancel;
-        }
-        catch (Exception ex)
-        {
-            attempt.AddError(ex, "Error sending POST request to invoke function");
-            return Result.Failure;
-        }
-
-        try
-        {
-            response.EnsureSuccessStatusCode();
-            return Result.Success;
-        }
-        catch (Exception ex)
-        {
-            attempt.AddError(ex, "Function execution failed");
-            return Result.Failure;
-        }
+            var response = await client.GetAsync(statusUrl, cancellation);
+            var content = await response.Content.ReadAsStringAsync(cancellation);
+            var statusResponse = JsonSerializer.Deserialize<StatusResponse>(content, CaseInsensitiveOptions)
+                ?? throw new InvalidOperationException("Status response was null");
+            return statusResponse;
+        }, cancellationToken);
     }
-
-    private async Task<HttpRequestMessage> BuildFunctionInvokeRequestAsync(
-        FunctionStepExecution step,
-        FunctionStepExecutionAttempt attempt,
-        CancellationToken cancellationToken)
-    {
-        string? functionKey = null;
-        try
-        {
-            // Try and get the function key from the actual step if it was defined.
-            await using var context = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
-            functionKey = await context.FunctionSteps
-                .AsNoTracking()
-                .Where(s => s.StepId == step.StepId)
-                .Select(s => s.FunctionKey)
-                .FirstOrDefaultAsync(cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "{ExecutionId} {Step} Error reading FunctionKey from database", step.ExecutionId, step);
-            attempt.AddWarning(ex, "Error reading function key from database");
-        }
-
-        var message = new HttpRequestMessage(HttpMethod.Post, step.FunctionUrl);
-
-        // Add function security code as a request header. If the function specific code was defined, use that.
-        // Otherwise, revert to the function app code if it was defined.
-        var functionApp = step.GetApp();
-
-        functionKey ??= functionApp?.FunctionAppKey;
-        
-        ArgumentException.ThrowIfNullOrEmpty(functionKey);
-
-        message.Headers.Add("x-functions-key", functionKey);
-        
-        if (string.IsNullOrEmpty(step.FunctionInput))
-        {
-            return message;
-        }
-        
-        // If the input for the function was defined, add it to the request content.
-        var parameters = step.StepExecutionParameters.ToStringDictionary();
-        var input = step.FunctionInput.Replace(parameters);
-        attempt.AddOutput($"Evaluated function input:\n{input}");
-        message.Content = new StringContent(input);
-
-        return message;
-    }
-
+    
     private async Task CancelAsync(
         FunctionStepExecution step, 
         FunctionStepExecutionAttempt attempt,
@@ -291,33 +325,49 @@ internal class FunctionStepExecutor(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "{ExecutionId} {Step} Error stopping function ", step.ExecutionId, step);
+            logger.LogError(ex, "{ExecutionId} {Step} Error stopping function ", step.ExecutionId, step);
             attempt.AddWarning(ex, "Error stopping function");
         }
     }
-
-    private async Task<StatusResponse> GetStatusWithRetriesAsync(
+    
+    private async Task<Result> PollUsingStatusCodesAsync(
+        FunctionStepExecutionAttempt attempt,
         HttpClient client,
-        FunctionStepExecution step,
-        string statusUrl,
+        string url,
         CancellationToken cancellationToken)
     {
-        var policy = Policy
-            .Handle<Exception>()
-            .WaitAndRetryAsync(
-            retryCount: MaxRefreshRetries,
-            sleepDurationProvider: _ => TimeSpan.FromMilliseconds(_pollingIntervalMs),
-            onRetry: (ex, _) =>
-                _logger.LogWarning(ex, "{ExecutionId} {Step} Error getting function instance status", step.ExecutionId, step));
-
-        return await policy.ExecuteAsync(async cancellation =>
+        attempt.AddOutput($"Polling URL:\n{url}");
+        using var response = await PollAndGetResponseAsync(client, url, cancellationToken);
+        
+        attempt.AddOutput($"Final polling response status code: {(int)response.StatusCode} {response.StatusCode}");
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (!string.IsNullOrEmpty(content))
         {
-            var response = await client.GetAsync(statusUrl, cancellation);
-            var content = await response.Content.ReadAsStringAsync(cancellation);
-            var statusResponse = JsonSerializer.Deserialize<StatusResponse>(content, CaseInsensitiveOptions)
-                ?? throw new InvalidOperationException("Status response was null");
-            return statusResponse;
-        }, cancellationToken);
+            attempt.AddOutput($"Final polling response content:\n{content}");
+        }
+
+        if (response.IsSuccessStatusCode)
+        {
+            return Result.Success;
+        }
+        
+        attempt.AddError("Polling response reported error status code");
+        return Result.Failure;
+    }
+    
+    private async Task<HttpResponseMessage> PollAndGetResponseAsync(
+        HttpClient client,
+        string url,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            await Task.Delay(_pollingIntervalMs, cancellationToken);
+            var response = await client.GetAsync(url, cancellationToken);
+            if (response.StatusCode != HttpStatusCode.Accepted)
+                return response;
+            response.Dispose();
+        }
     }
 
     private record StartResponse(

--- a/src/Biflow.Ui.Api/Endpoints/StepsCreateEndpoints.cs
+++ b/src/Biflow.Ui.Api/Endpoints/StepsCreateEndpoints.cs
@@ -498,7 +498,7 @@ public abstract class StepsCreateEndpoints : IEndpoints
                     FunctionUrl = stepDto.FunctionUrl,
                     FunctionInput = stepDto.FunctionInput,
                     FunctionInputFormat = stepDto.FunctionInputFormat,
-                    FunctionIsDurable = stepDto.FunctionIsDurable,
+                    DisableAsyncPattern = stepDto.DisableAsyncPattern,
                     FunctionKey = stepDto.FunctionKey,
                     Parameters = parameters,
                     Dependencies = dependencies,

--- a/src/Biflow.Ui.Api/Endpoints/StepsUpdateEndpoints.cs
+++ b/src/Biflow.Ui.Api/Endpoints/StepsUpdateEndpoints.cs
@@ -495,7 +495,7 @@ public abstract class StepsUpdateEndpoints : IEndpoints
                     FunctionUrl = stepDto.FunctionUrl,
                     FunctionInput = stepDto.FunctionInput,
                     FunctionInputFormat = stepDto.FunctionInputFormat,
-                    FunctionIsDurable = stepDto.FunctionIsDurable,
+                    DisableAsyncPattern = stepDto.DisableAsyncPattern,
                     FunctionKey = stepDto.FunctionKey,
                     Parameters = parameters,
                     Dependencies = dependencies,

--- a/src/Biflow.Ui.Api/Models/Step/FunctionStepDto.cs
+++ b/src/Biflow.Ui.Api/Models/Step/FunctionStepDto.cs
@@ -8,7 +8,7 @@ public record FunctionStepDto : StepDto
     public required string FunctionUrl { get; init; }
     public required string? FunctionInput { get; init; }
     public FunctionInputFormat FunctionInputFormat { get; init; } = FunctionInputFormat.PlainText;
-    public required bool FunctionIsDurable { get; init; }
+    public required bool DisableAsyncPattern { get; init; }
     public string? FunctionKey { get; init; }
     public StepParameterDto[] Parameters { get; init; } = [];
 }

--- a/src/Biflow.Ui.Core/Mediator/Commands/Step/CreateFunctionStep.cs
+++ b/src/Biflow.Ui.Core/Mediator/Commands/Step/CreateFunctionStep.cs
@@ -7,7 +7,7 @@ public class CreateFunctionStepCommand : CreateStepCommand<FunctionStep>
     public required string FunctionUrl { get; init; }
     public required string? FunctionInput { get; init; }
     public required FunctionInputFormat FunctionInputFormat { get; init; }
-    public required bool FunctionIsDurable { get; init; }
+    public required bool DisableAsyncPattern { get; init; }
     public required string? FunctionKey { get; init; }
     public required CreateStepParameter[] Parameters { get; init; }
 }
@@ -45,7 +45,7 @@ internal class CreateFunctionStepCommandHandler(
             FunctionUrl = request.FunctionUrl,
             FunctionInput = request.FunctionInput,
             FunctionInputFormat = request.FunctionInputFormat,
-            FunctionIsDurable = request.FunctionIsDurable,
+            DisableAsyncPattern = request.DisableAsyncPattern,
             FunctionKey = request.FunctionKey
         };
         

--- a/src/Biflow.Ui.Core/Mediator/Commands/Step/UpdateFunctionStep.cs
+++ b/src/Biflow.Ui.Core/Mediator/Commands/Step/UpdateFunctionStep.cs
@@ -11,7 +11,7 @@ public class UpdateFunctionStepCommand : UpdateStepCommand<FunctionStep>
     public required string FunctionUrl { get; init; }
     public required string? FunctionInput { get; init; }
     public required FunctionInputFormat FunctionInputFormat { get; init; }
-    public required bool FunctionIsDurable { get; init; }
+    public required bool DisableAsyncPattern { get; init; }
     /// <summary>
     /// If null, the previous FunctionKey value will be retained.
     /// If empty string, the FunctionKey value will be cleared.
@@ -60,7 +60,7 @@ internal class UpdateFunctionStepCommandHandler(
         step.FunctionUrl = request.FunctionUrl;
         step.FunctionInput = request.FunctionInput;
         step.FunctionInputFormat = request.FunctionInputFormat;
-        step.FunctionIsDurable = request.FunctionIsDurable;
+        step.DisableAsyncPattern = request.DisableAsyncPattern;
         if (request.FunctionKey is not null)
         {
             step.FunctionKey = request.FunctionKey;

--- a/src/Biflow.Ui/Shared/Executions/StepExecutionDetails.razor
+++ b/src/Biflow.Ui/Shared/Executions/StepExecutionDetails.razor
@@ -345,10 +345,10 @@
                     <pre><code>@function.FunctionInput</code></pre>
                 </dd>
                 <dt class="col-sm-3">
-                    Is durable
+                    Disable async pattern
                 </dt>
                 <dd class="col-sm-9">
-                    @function.FunctionIsDurable
+                    @function.DisableAsyncPattern
                 </dd>
                 <dt class="col-sm-3">
                     Function App id

--- a/src/Biflow.Ui/Shared/StepEditModal/FunctionStepEditModal.razor
+++ b/src/Biflow.Ui/Shared/StepEditModal/FunctionStepEditModal.razor
@@ -93,13 +93,19 @@
 
         <div class="row mt-3">
             <div class="col-md-4 d-md-flex justify-content-end">
-                <label class="form-check-label mb-lg-0" for="function_is_durable">Is durable function</label>
+                <label class="form-check-label mb-lg-0"
+                       for="disable_async_pattern">
+                    Disable async pattern
+                    <HxPopover Trigger="PopoverTrigger.Hover" Html Content="@DisableAsyncPatternInfoContent">
+                        <SvgIcon Icon="LucideIcon.Info" />
+                    </HxPopover>
+                </label>
             </div>
             <div class="col-md-6">
                 <div class="form-check form-check-inline">
-                    <input type="checkbox" class="form-check-input" id="function_is_durable"
-                           checked=@Step.FunctionIsDurable
-                           @bind-value="Step.FunctionIsDurable">
+                    <input type="checkbox" class="form-check-input" id="disable_async_pattern"
+                           checked=@Step.DisableAsyncPattern
+                           @bind-value="Step.DisableAsyncPattern">
                 </div>
             </div>
         </div>

--- a/src/Biflow.Ui/Shared/StepEditModal/FunctionStepEditModal.razor.cs
+++ b/src/Biflow.Ui/Shared/StepEditModal/FunctionStepEditModal.razor.cs
@@ -9,6 +9,14 @@ public partial class FunctionStepEditModal(
     : StepEditModal<FunctionStep>(mediator, toaster, dbContextFactory)
 {
     internal override string FormId => "function_step_edit_form";
+    
+    private const string DisableAsyncPatternInfoContent = """
+        <div>
+            Option to disable async polling of status for durable functions.
+            If enabled, the step will be completed immediately after the function has been successfully invoked.
+            This option has no effect when invoking non-durable functions.
+        </div>
+        """;
 
     private const string ParametersInfoContent = """
         <div>
@@ -86,7 +94,7 @@ public partial class FunctionStepEditModal(
             FunctionUrl = step.FunctionUrl,
             FunctionInput = step.FunctionInput,
             FunctionInputFormat = step.FunctionInputFormat,
-            FunctionIsDurable = step.FunctionIsDurable,
+            DisableAsyncPattern = step.DisableAsyncPattern,
             FunctionKey = step.FunctionKey,
             Dependencies = dependencies,
             ExecutionConditionParameters = executionConditionParameters,
@@ -147,7 +155,7 @@ public partial class FunctionStepEditModal(
             FunctionUrl = step.FunctionUrl,
             FunctionInput = step.FunctionInput,
             FunctionInputFormat = step.FunctionInputFormat,
-            FunctionIsDurable = step.FunctionIsDurable,
+            DisableAsyncPattern = step.DisableAsyncPattern,
             FunctionKey = step.FunctionKey,
             Dependencies = dependencies,
             ExecutionConditionParameters = executionConditionParameters,


### PR DESCRIPTION
Refactored property `FunctionIsDurable` in `FunctionStep` and `FunctionStepExecution` to `DisableAsyncPattern` – similar to `HttpStep`.

This is a more convenient option, because now polling is done automatically by default in case of durable functions, whereas previously users had to specifically mark invoked functions as durable for async polling to take place.

Introduces breaking change in migrations. 💥 The column is simply renamed, and its values are set to `false`. This means that if there are any function steps invoking durable functions where `FunctionIsDurable == false`, then these steps should be updated with `DisableAsyncPattern = true`.